### PR TITLE
Change CRF step size from 1 to 0.5

### DIFF
--- a/Encoding/x264Enc.vb
+++ b/Encoding/x264Enc.vb
@@ -212,7 +212,7 @@ Public Class x264Params
         .Name = "Quant",
         .Text = "Quality",
         .Init = 22,
-        .Config = {0, 69, 1, 1}}
+        .Config = {0, 69, 0.5, 1}}
 
     Property Preset As New OptionParam With {
         .Switch = "--preset",

--- a/Encoding/x265Enc.vb
+++ b/Encoding/x265Enc.vb
@@ -223,7 +223,7 @@ Public Class x265Params
         .Text = "Quality",
         .DefaultValue = 28,
         .Value = 18,
-        .Config = {0, 51, 1, 1}}
+        .Config = {0, 51, 0.5, 1}}
 
     Property chunkstart As New NumParam With {
         .Switch = "--chunk-start",


### PR DESCRIPTION
Step size should be 0.5 in order to be more compliant with other step sizes and to its possible values - value of 1 is a little bit too  extreme/huge.