### PR TITLE
Fix: Subtitles ignoring the Demux Subtitles option setting

### DIFF
--- a/General/MediaInfo.vb
+++ b/General/MediaInfo.vb
@@ -162,16 +162,6 @@ Public Class MediaInfo
                     subtitle.Format = GetText(index, "Format")
                     subtitle.Size = GetText(index, "StreamSize").ToInt
 
-                    Select Case p.DemuxSubtitles
-                         Case DemuxMode.All
-                              subtitle.Enabled = True
-                         Case DemuxMode.None
-                              subtitle.Enabled = False
-                         Case DemuxMode.Preferred, DemuxMode.Dialog
-                              Dim autoCode = p.PreferredSubtitles.ToLower.SplitNoEmptyAndWhiteSpace(",", ";", " ")
-                              subtitle.Enabled = autoCode.ContainsAny("all", subtitle.Language.TwoLetterCode, subtitle.Language.ThreeLetterCode)
-                    End Select
-                                    
                     Dim autoCode = p.PreferredSubtitles.ToLower.SplitNoEmptyAndWhiteSpace(",", ";", " ")
                     subtitle.Enabled = autoCode.ContainsAny("all", subtitle.Language.TwoLetterCode, subtitle.Language.ThreeLetterCode) OrElse p.DemuxSubtitles = DemuxMode.All
 

--- a/General/MediaInfo.vb
+++ b/General/MediaInfo.vb
@@ -162,6 +162,16 @@ Public Class MediaInfo
                     subtitle.Format = GetText(index, "Format")
                     subtitle.Size = GetText(index, "StreamSize").ToInt
 
+                    Select Case p.DemuxSubtitles
+                         Case DemuxMode.All
+                              subtitle.Enabled = True
+                         Case DemuxMode.None
+                              subtitle.Enabled = False
+                         Case DemuxMode.Preferred, DemuxMode.Dialog
+                              Dim autoCode = p.PreferredSubtitles.ToLower.SplitNoEmptyAndWhiteSpace(",", ";", " ")
+                              subtitle.Enabled = autoCode.ContainsAny("all", subtitle.Language.TwoLetterCode, subtitle.Language.ThreeLetterCode)
+                    End Select
+                                    
                     Dim autoCode = p.PreferredSubtitles.ToLower.SplitNoEmptyAndWhiteSpace(",", ";", " ")
                     subtitle.Enabled = autoCode.ContainsAny("all", subtitle.Language.TwoLetterCode, subtitle.Language.ThreeLetterCode) OrElse p.DemuxSubtitles = DemuxMode.All
 

--- a/General/Muxer.vb
+++ b/General/Muxer.vb
@@ -196,14 +196,6 @@ Public MustInherit Class Muxer
             End If
         Next
 
-        If p.PreferredSubtitles <> "" AndAlso Subtitles.Count = 0 AndAlso
-            p.FirstOriginalSourceFile.Ext.EqualsAny("mkv", "mp4", "m2ts") AndAlso
-            MediaInfo.GetSubtitleCount(p.FirstOriginalSourceFile) > 0 AndAlso
-            TypeOf Me Is MkvMuxer Then
-
-            Subtitles.AddRange(Subtitle.Create(p.FirstOriginalSourceFile))
-        End If
-
         For Each i In files
             If g.IsSourceSameOrSimilar(i) Then
                 If Not TypeOf Me Is WebMMuxer Then


### PR DESCRIPTION
When using a MKV source file and muxing into a MKV while having *Prefered Subtitles* filled, the *Demux Subtitles = None* setting will be ignored and all subtitles are prepared to beeing muxed into the container.
You have to go to *Container Options* and remove them every time by hand.

Don't know the purpose of this lines, but they seem to produce this unexpected/unwanted behavior.