### PR TITLE
Apply quality definitions from x264

### DIFF
--- a/Controls/x265Control.vb
+++ b/Controls/x265Control.vb
@@ -113,15 +113,15 @@ Public Class x265Control
         components = New System.ComponentModel.Container()
 
         QualityDefinitions = New List(Of QualityItem) From {
-            New QualityItem(10, "Super High", "Super high quality and file size)"),
-            New QualityItem(12, "Very High", "Very high quality and file size)"),
-            New QualityItem(14, "Higher", "Higher quality and file size)"),
-            New QualityItem(16, "High", "High quality and file size)"),
-            New QualityItem(18, "Medium", "Medium quality and file size)"),
-            New QualityItem(20, "Low", "Low quality and file size)"),
-            New QualityItem(22, "Lower", "Lower quality and file size)"),
-            New QualityItem(24, "Very Low", "Very low quality and file size)"),
-            New QualityItem(26, "Super Low", "Super low quality and file size)")}
+            New QualityItem(14, "Super High", "Super high quality and file size)"),
+            New QualityItem(16, "Very High", "Very high quality and file size)"),
+            New QualityItem(18, "Higher", "Higher quality and file size)"),
+            New QualityItem(20, "High", "High quality and file size)"),
+            New QualityItem(22, "Medium", "Medium quality and file size)"),
+            New QualityItem(24, "Low", "Low quality and file size)"),
+            New QualityItem(26, "Lower", "Lower quality and file size)"),
+            New QualityItem(28, "Very Low", "Very low quality and file size)"),
+            New QualityItem(30, "Super Low", "Super low quality and file size)")}
 
         Encoder = enc
         Params = Encoder.Params


### PR DESCRIPTION
Apply quality definitions from x264, because they make more sense to include x265's default CRF value (28) and add lower values in general, because values 10 and 12 mostly lead to very big files - as big as the source - without visible quality improvements. With x265 you also use lower CRF values than with x264 due to its improvements.

![StaxRip0](https://user-images.githubusercontent.com/50659978/84602463-f60bae00-ae87-11ea-959f-b5d7096436dd.JPG)


### Current settings:

https://github.com/staxrip/staxrip/blob/master/Controls/x264Control.vb#L116-L125
https://github.com/staxrip/staxrip/blob/3317148b638d2a9d3944e3367433a72e4798d61e/Controls/x264Control.vb#L116-L125


https://github.com/staxrip/staxrip/blob/master/Controls/x264Control.vb#L116-L125
https://github.com/staxrip/staxrip/blob/3317148b638d2a9d3944e3367433a72e4798d61e/Controls/x265Control.vb#L115-L124