### PR TITLE
Include beta versions for update checker and show changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - mkvtoolnix 48
 - ec3 file extension support for eac3 files.
 - R210/V210 video output using ffmpeg.
+- Include beta versions for update checker and show changelog (Dendraspis)
 
 
 2.1.3.7 Beta

--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -3422,6 +3422,10 @@ Public Class MainForm
             b.Field = NameOf(s.CheckForUpdates)
 
             b = ui.AddBool
+            b.Text = "Include beta versions for update check"
+            b.Field = NameOf(s.CheckForUpdatesBeta)
+
+            b = ui.AddBool
             b.Text = "Use included portable AviSynth"
             b.Field = NameOf(s.UsePortableAviSynth)
 
@@ -3510,8 +3514,8 @@ Public Class MainForm
             b.Help = "If you disable this you can still right-click menu items to show the tooltip."
             b.Field = NameOf(s.EnableTooltips)
 
-            ui.AddControlPage(New PreprocessingControl, "Preprocessing").FormSizeScaleFactor = New Size(38, 21)
-            ui.FormSizeScaleFactor = New Size(31, 21)
+            ui.AddControlPage(New PreprocessingControl, "Preprocessing").FormSizeScaleFactor = New Size(38, 22)
+            ui.FormSizeScaleFactor = New Size(31, 22)
 
             Dim systemPage = ui.CreateFlowPage("System", True)
 

--- a/General/ApplicationSettings.vb
+++ b/General/ApplicationSettings.vb
@@ -12,6 +12,7 @@ Public Class ApplicationSettings
     Public AviSynthProfiles As List(Of FilterCategory)
     Public CharacterLimit As Integer
     Public CheckForUpdates As Boolean
+    Public CheckForUpdatesBeta As Boolean
     Public CheckForUpdatesDismissed As String
     Public CheckForUpdatesLastRequest As DateTime
     Public CheckForUpdatesQuestion As Boolean

--- a/General/Update.vb
+++ b/General/Update.vb
@@ -1,4 +1,6 @@
 ﻿
+Imports System.ComponentModel
+Imports System.Net
 Imports System.Net.Http
 Imports System.Text.RegularExpressions
 
@@ -14,35 +16,141 @@ Public Class Update
         End If
     End Sub
 
-    Shared Async Sub CheckForUpdate(Optional force As Boolean = False)
+    Shared Async Sub CheckForUpdate(Optional force As Boolean = False, Optional includeBeta As Boolean = False)
         Try
             If Not s.CheckForUpdates AndAlso Not force Then
                 Exit Sub
             End If
 
-            If (DateTime.Now - s.CheckForUpdatesLastRequest).TotalHours > 24 OrElse force Then
-                Dim response = Await HttpClient.GetAsync("https://github.com/staxrip/staxrip/releases")
-                response.EnsureSuccessStatusCode()
-                Dim content = Await response.Content.ReadAsStringAsync()
-                Dim match = Regex.Match(content, "title=""(\d+\.\d+\.\d+\.\d+)""")
-                Dim onlineVersion = Version.Parse(match.Groups(1).Value)
+            If s.CheckForUpdatesBeta Then
+                includeBeta = True
+            End If
+
+            If (DateTime.Now - s.CheckForUpdatesLastRequest).TotalHours >= 24 OrElse force Then
+                Dim changelogUrl = "https://raw.githubusercontent.com/staxrip/staxrip/master/Changelog.md"
+                Dim betaSourcesUrl = "https://staxrip.readthedocs.io/introduction.html"
+                Dim dropboxUrl = "https://www.dropbox.com/sh/4ctl2y928xkak4f/AAADEZj_hFpGQaNOdd3yqcAHa?dl=0&lst="
+                Dim stableUrl = "https://github.com/staxrip/staxrip/releases"
+
                 Dim currentVersion = Reflection.Assembly.GetEntryAssembly.GetName.Version
+                Dim latestVersions = New List(Of (Version As Version, Status As String, SourceSite As String, DownloadUri As String, FileName As String))
 
-                If onlineVersion > currentVersion AndAlso (s.CheckForUpdatesDismissed = "" OrElse
-                    Version.Parse(s.CheckForUpdatesDismissed) <> onlineVersion OrElse force) Then
+                Dim response = Await HttpClient.GetAsync(stableUrl)
+                If response.IsSuccessStatusCode Then
+                    Dim content = Await response.Content.ReadAsStringAsync()
+                    Dim titleMatch = Regex.Match(content, "title=""(\d+\.\d+\.\d+\.\d+)""")
+                    Dim onlineVersion = Version.Parse(titleMatch.Groups(1).Value)
+                    Dim linkMatch = Regex.Match(content, "(https://[^""]*/([^""/]*StaxRip[^""?]*)[^""]*)\\""")
 
-                    Using td As New TaskDialog(Of String)
-                        td.MainInstruction = "A newer version was found online: " + match.Groups(1).Value
-                        td.AddCommand("Show download page", "download")
-                        td.AddCommand("Dismiss " + match.Groups(1).Value, "dismiss")
+                    latestVersions.Add((onlineVersion, "Stable", stableUrl, linkMatch.Groups(1).Value, linkMatch.Groups(2).Value))
+                ElseIf Not includeBeta Then
+                    response.EnsureSuccessStatusCode()
+                End If
 
-                        Select Case td.Show
-                            Case "download"
-                                g.ShellExecute("https://github.com/staxrip/staxrip/releases")
-                            Case "dismiss"
-                                s.CheckForUpdatesDismissed = onlineVersion.ToString
-                        End Select
-                    End Using
+
+                If includeBeta Then
+                    Try
+                        Dim dropboxResponse = Await HttpClient.GetAsync(dropboxUrl)
+                        If Not dropboxResponse.IsSuccessStatusCode Then
+                            Dim betaSourcesResponse = Await HttpClient.GetAsync(betaSourcesUrl)
+                            Dim betaSourcesContent = Await betaSourcesResponse.Content.ReadAsStringAsync()
+                            Dim dropboxMatch = Regex.Match(betaSourcesContent, "(https://www\.dropbox\.com[^""]*)""")
+
+                            If dropboxMatch.Success Then
+                                dropboxResponse = Await HttpClient.GetAsync(dropboxMatch.Groups(1).Value)
+                            End If
+                        End If
+
+                        dropboxResponse.EnsureSuccessStatusCode()
+                        Dim dropboxContent = Await dropboxResponse.Content.ReadAsStringAsync()
+                        Dim betaMatches = Regex.Matches(dropboxContent, "(https://[^""]*/([^""/]*StaxRip[^""?]*)[^""]*)\\""")
+
+                        If betaMatches.Count > 0 Then
+                            Dim sortedMatches = New Match(betaMatches.Count - 1) {}
+                            betaMatches.CopyTo(sortedMatches, 0)
+                            sortedMatches.OrderBy(Function(x) Regex.Replace(x.Groups(2).Value, "\d+", "$&".PadLeft(11, "0"c)))
+                            Dim lastMatch = sortedMatches.Last()
+
+                            Dim uri = lastMatch.Groups(1).Value.Replace("?dl=0", "?dl=1")
+                            Dim filename = lastMatch.Groups(2).Value
+                            Dim versionMatch = Regex.Match(filename, ".*(\d+\.\d+\.\d+\.\d+).*")
+                            Dim betaOnlineVersion = Version.Parse(versionMatch.Groups(1).Value)
+
+                            latestVersions.Add((betaOnlineVersion, "Beta", stableUrl, uri, filename))
+                        End If
+                    Catch
+                    End Try
+                End If
+
+
+                If latestVersions.Count > 0 Then
+                    Dim latestVersion = latestVersions.OrderBy(Function(x) x.Version).Last()
+
+                    If latestVersion.Version > currentVersion AndAlso (s.CheckForUpdatesDismissed = "" OrElse Version.Parse(s.CheckForUpdatesDismissed) <> latestVersion.Version OrElse force) Then
+                        Using td As New TaskDialog(Of String)
+                            td.MainInstruction = "A new " + latestVersion.Status + " version was found: " + latestVersion.Version.ToString()
+
+                            Dim changelogResponse = Await HttpClient.GetAsync(changelogUrl)
+                            If changelogResponse.IsSuccessStatusCode Then
+                                Dim changelogContent = Await changelogResponse.Content.ReadAsStringAsync()
+                                Dim splits = Regex.Split(changelogContent, "\n\n\n")
+                                If splits.Any() Then
+                                    Dim split = splits.Where(Function(x) x.Contains(latestVersion.Version.ToString()))?.LastOrDefault()
+                                    If Not String.IsNullOrWhiteSpace(split) Then
+                                        Dim changes = 0
+
+                                        td.Content += "Changes in this version:" + BR
+                                        For Each line As String In Regex.Split(split, "\n")
+                                            If changes >= 20 Then
+                                                td.Content += "..."
+                                                Exit For
+                                            ElseIf line.StartsWith("-") Then
+                                                td.Content += line + BR
+                                                changes += 1
+                                            End If
+                                        Next
+                                    End If
+                                End If
+                            End If
+
+                            td.AddCommand("Download and save as...", "downloadsaveas")
+                            td.AddCommand("Download via browser", "downloadbrowser")
+                            td.AddCommand("Open source website", "open")
+                            td.AddCommand("Dismiss version " + latestVersion.Version.ToString(), "dismiss")
+
+                            Select Case td.Show
+                                Case "downloadsaveas"
+                                    Dim saveFileDialog = New SaveFileDialog With {
+                                        .AddExtension = True,
+                                        .AutoUpgradeEnabled = True,
+                                        .CheckFileExists = False,
+                                        .DefaultExt = "7z",
+                                        .FileName = latestVersion.FileName,
+                                        .Filter = "7-zip archive (*.7z)|*.7z",
+                                        .OverwritePrompt = True,
+                                        .Title = "Save new " + latestVersion.Status + " version as..."
+                                    }
+                                    If saveFileDialog.ShowDialog() = DialogResult.OK Then
+                                        Using client As New WebClient()
+                                            AddHandler client.DownloadFileCompleted, AddressOf OnDownloadComplete
+                                            client.DownloadFileAsync(New Uri(latestVersion.DownloadUri), saveFileDialog.FileName)
+
+                                            MessageBox.Show("This may take a while." + BR + "You'll be informed when the download finished." + BR2 + "Please do not close this instance till the download is finished!", "Downloading...", MessageBoxButtons.OK)
+                                        End Using
+                                    End If
+                                Case "downloadbrowser"
+                                    g.ShellExecute(latestVersion.DownloadUri)
+                                Case "open"
+                                    g.ShellExecute(latestVersion.SourceSite)
+                                Case "dismiss"
+                                    s.CheckForUpdatesDismissed = latestVersion.Version.ToString()
+                            End Select
+                        End Using
+
+                    ElseIf force Then
+                        MsgInfo("No update available.")
+                    End If
+
                 ElseIf force Then
                     MsgInfo("No update available.")
                 End If
@@ -52,4 +160,14 @@ Public Class Update
         Catch
         End Try
     End Sub
+
+
+    Private Shared Sub OnDownloadComplete(ByVal sender As Object, ByVal e As AsyncCompletedEventArgs)
+        If Not e.Cancelled AndAlso e.Error Is Nothing Then
+            MessageBox.Show("Download successed!")
+        Else
+            MessageBox.Show("Download failed!")
+        End If
+    End Sub
+
 End Class


### PR DESCRIPTION
At the moment beta versions are only scrapped from DropBox. The link to the DropBox folder is hardcoded. If it's not reachable, the current/changed DropBox link if fetched from the docs (https://staxrip.readthedocs.io/introduction.html).
**If  the DropBox folder/link changes, the code should be adjusted to prevent unnecessary web queries.**

#### Adds checkbox for including beta versions and enlarges the SimpleUI a little bit to fit the new option:
![StaxRip1](https://user-images.githubusercontent.com/50659978/86568249-de968100-bf6c-11ea-9a41-7ffcb802bff2.JPG)

---------------------

#### - Gives option to directly download the new version
#### - Shows the changelog (if found)
![StaxRip2](https://user-images.githubusercontent.com/50659978/86569035-22d65100-bf6e-11ea-9eb2-5933ef1f3b1c.JPG)

