### PR TITLE
Open relative paths

### DIFF
--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -1824,6 +1824,8 @@ Public Class MainForm
     End Sub
 
     Sub OpenAnyFile(files As IEnumerable(Of String))
+        files = files.Select(Function(filePath) New FileInfo(filePath).FullName).AsEnumerable()
+
         If files(0).Ext = "srip" Then
             OpenProject(files(0))
         ElseIf FileTypes.Video.Contains(files(0).Ext.Lower) Then

--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -1854,6 +1854,8 @@ Public Class MainForm
         AddHandler Disposed, Sub() FileHelp.Delete(recoverProjectPath)
 
         Try
+            files = files.Select(Function(filePath) New FileInfo(filePath).FullName).AsEnumerable()
+
             If g.ShowVideoSourceWarnings(files) Then
                 Throw New AbortException
             End If


### PR DESCRIPTION
With this extension this is possible now:

`D:\> staxrip.exe video.mkv`
`D:\MusicVideos> staxrip.exe .\video.mkv`
`D:\> C:\Apps\StaxRip\staxrip.exe .\Music\video.mkv`
`D:\Videos> C:\Apps\StaxRip\staxrip.exe ".\video to test.mkv"`

...which is very very useful when you work with CommandPrompt/PowerShell.

Before you got DirectoryNotFoundExceptions and/or problems due to relative directories inside the filer scripts.