### PR TITLE
bnNext extension (includes #268 and #269)

### DIFF
--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -3448,8 +3448,8 @@ Public Class MainForm
             b.Help = "If you disable this you can still right-click menu items to show the tooltip."
             b.Field = NameOf(s.EnableTooltips)
 
-            ui.AddControlPage(New PreprocessingControl, "Preprocessing").FormSizeScaleFactor = New Size(38, 21)
-            ui.FormSizeScaleFactor = New Size(31, 21)
+            ui.AddControlPage(New PreprocessingControl, "Preprocessing").FormSizeScaleFactor = New Size(38, 22)
+            ui.FormSizeScaleFactor = New Size(31, 22)
 
             Dim systemPage = ui.CreateFlowPage("System", True)
 

--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -3958,8 +3958,10 @@ Public Class MainForm
 
             AddJob(False, Nothing, position)
 
-            If showJobsDialog Then
-                Me.ShowJobsDialog()
+            If ModifierKeys.HasFlag(Keys.Control) Then
+                bnNext.ShowBold()
+            Else
+                ShowJobsDialog()
             End If
         Else
             Assistant()

--- a/Forms/MainForm.vb
+++ b/Forms/MainForm.vb
@@ -3958,10 +3958,10 @@ Public Class MainForm
 
             AddJob(False, Nothing, position)
 
-            If ModifierKeys.HasFlag(Keys.Control) Then
+            If showJobsDialog Then
                 bnNext.ShowBold()
             Else
-                ShowJobsDialog()
+                Me.ShowJobsDialog()
             End If
         Else
             Assistant()

--- a/General/Extensions.vb
+++ b/General/Extensions.vb
@@ -888,6 +888,11 @@ Module ControlExtension
     End Sub
 
     <Extension()>
+    Sub SetFontSize(instance As Control, fontSize As Single)
+        instance.Font = New Font(instance.Font.FontFamily, fontSize)
+    End Sub
+
+    <Extension()>
     Sub AddClickAction(instance As Control, action As Action)
         AddHandler instance.Click, Sub() action()
     End Sub

--- a/General/JobManager.vb
+++ b/General/JobManager.vb
@@ -87,7 +87,7 @@ Public Class JobManager
         SaveJobs(jobs)
     End Sub
 
-    Shared Sub AddJob(name As String, path As String)
+    Shared Sub AddJob(name As String, path As String, Optional position As Integer = -1)
         Dim jobs = GetJobs()
 
         For Each job In jobs.ToArray
@@ -96,7 +96,22 @@ Public Class JobManager
             End If
         Next
 
-        jobs.Add(New Job(name, path))
+        If position = -1 Then
+            jobs.Add(New Job(name, path))
+        ElseIf position >= 0 Then
+            If jobs.Count > position Then
+                jobs.Insert(position, New Job(name, path))
+            Else
+                jobs.Add(New Job(name, path))
+            End If
+        Else
+            If -jobs.Count - 1 <= position Then
+                jobs.Insert(jobs.Count + position + 1, New Job(name, path))
+            Else
+                jobs.Add(New Job(name, path))
+            End If
+        End If
+
         SaveJobs(jobs)
     End Sub
 

--- a/UI/Controls/Controls.vb
+++ b/UI/Controls/Controls.vb
@@ -1128,14 +1128,8 @@ Namespace UI
         End Property
 
         Protected Overrides Sub OnClick(e As EventArgs)
-            If Not ClickAction Is Nothing Then
-                ClickAction.Invoke()
-            End If
-
-            If Not ContextMenuStrip Is Nothing Then
-                ContextMenuStrip.Show(Me, 0, Height)
-            End If
-
+            ClickAction?.Invoke()
+            ContextMenuStrip?.Show(Me, 0, Height)
             MyBase.OnClick(e)
         End Sub
 


### PR DESCRIPTION
#### Includes #268 and #269 

This basically extends #269 to give better and more intuitive usage possibilities.
Also solves the problem with pressed modifier keys and opening message boxes in between.
------

- Change bnSkip_Click() to bnNext_Skip() (see #268)
- Add possibility to add new jobs at specific position (see #269)
- Add ContextMenu to bnNext for all 4 possible options (to top/bottom / w/(o) opening Jobs)
- Change button text when modifier keys are pressed

### Rightclick:
![StaxRipNext](https://user-images.githubusercontent.com/50659978/87554380-5b83d200-c6b4-11ea-9dbc-c5f0244e3c51.JPG)

--------

### Holding SHIFT:
![StaxRipNext2](https://user-images.githubusercontent.com/50659978/87554382-5c1c6880-c6b4-11ea-99b2-7ef19612b4a3.JPG)
