### PR TITLE
Re-fix v2.1.3.7 DGIndex enabled by default (Changelog)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 ============
 
 - AviSynth soft link fix.
+- DGIndex re-enabled by default for VOB/MPG.
 
 
 2.1.3.6 Beta


### PR DESCRIPTION
#265 was merged, but the change is gone - History of Changelog.md doesn't show any commits that deleted it.  🤨 