### PR TITLE
Fixes x265 Presets and Tunes

### DIFF
--- a/Encoding/x265Enc.vb
+++ b/Encoding/x265Enc.vb
@@ -1303,6 +1303,8 @@ Public Class x265Params
     Sub ApplyPresetValues()
         AQmode.Value = 2
         AQStrength.Value = 1
+        CUtree.Value = True
+        Deblock.Value = True
         DeblockA.Value = 0
         DeblockB.Value = 0
         FrameThreads.Value = 0
@@ -1327,8 +1329,6 @@ Public Class x265Params
                 BAdapt.Value = 0
                 BFrames.Value = 3
                 BIntra.Value = False
-                CUtree.Value = False
-                Deblock.Value = True
                 EarlySkip.Value = True
                 FastIntra.Value = True
                 LimitRefs.Value = 0
@@ -1357,8 +1357,6 @@ Public Class x265Params
                 BAdapt.Value = 0
                 BFrames.Value = 3
                 BIntra.Value = False
-                CUtree.Value = False
-                Deblock.Value = True
                 EarlySkip.Value = True
                 FastIntra.Value = True
                 LimitRefs.Value = 0
@@ -1384,11 +1382,8 @@ Public Class x265Params
                 BAdapt.Value = 0
                 BFrames.Value = 4
                 BIntra.Value = False
-                CUtree.Value = False
-                Deblock.Value = True
                 EarlySkip.Value = True
                 FastIntra.Value = True
-                MaxCuSize.Value = 1
                 MaxMerge.Value = 2
                 MErange.Value = 57
                 RCLookahead.Value = 15
@@ -1410,8 +1405,6 @@ Public Class x265Params
                 BAdapt.Value = 0
                 BFrames.Value = 4
                 BIntra.Value = False
-                CUtree.Value = False
-                Deblock.Value = True
                 EarlySkip.Value = True
                 FastIntra.Value = True
                 MaxMerge.Value = 2
@@ -1432,11 +1425,9 @@ Public Class x265Params
             Case 4 'fast
                 [Me].Value = 1
                 AMP.Value = False
-                BAdapt.Value = 2
+                BAdapt.Value = 0
                 BFrames.Value = 4
                 BIntra.Value = False
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = False
                 FastIntra.Value = True
                 MaxMerge.Value = 2
@@ -1460,8 +1451,6 @@ Public Class x265Params
                 BAdapt.Value = 2
                 BFrames.Value = 4
                 BIntra.Value = False
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = True
                 FastIntra.Value = False
                 MaxMerge.Value = 2
@@ -1485,8 +1474,6 @@ Public Class x265Params
                 BAdapt.Value = 2
                 BFrames.Value = 4
                 BIntra.Value = False
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = False
                 FastIntra.Value = False
                 LimitModes.Value = True
@@ -1513,22 +1500,20 @@ Public Class x265Params
                 BAdapt.Value = 2
                 BFrames.Value = 8
                 BIntra.Value = True
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = False
                 FastIntra.Value = False
                 LimitModes.Value = True
                 LimitRefs.Value = 0
                 LimitTU.Value = 4
-                LookaheadSlices.Value = 4
-                MaxMerge.Value = 5
+                LookaheadSlices.Value = 1
+                MaxMerge.Value = 4
                 MErange.Value = 57
                 PsyRDOQ.Value = 1
                 RCLookahead.Value = 40
                 RD.Value = 6
                 rdoqLevel.Value = 2
                 Rect.Value = True
-                Ref.Value = 4
+                Ref.Value = 5
                 SAO.Value = True
                 Scenecut.Value = 40
                 SignHide.Value = True
@@ -1543,13 +1528,11 @@ Public Class x265Params
                 BAdapt.Value = 2
                 BFrames.Value = 8
                 BIntra.Value = True
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = False
                 FastIntra.Value = False
                 LimitRefs.Value = 0
                 LimitTU.Value = 4
-                LookaheadSlices.Value = 4
+                LookaheadSlices.Value = 1
                 MaxMerge.Value = 5
                 MErange.Value = 57
                 PsyRDOQ.Value = 1
@@ -1572,12 +1555,10 @@ Public Class x265Params
                 BAdapt.Value = 2
                 BFrames.Value = 8
                 BIntra.Value = True
-                CUtree.Value = True
-                Deblock.Value = True
                 EarlySkip.Value = False
                 FastIntra.Value = False
                 LimitRefs.Value = 0
-                LookaheadSlices.Value = 0
+                LookaheadSlices.Value = 1
                 MaxMerge.Value = 5
                 MErange.Value = 92
                 RCLookahead.Value = 60
@@ -1599,6 +1580,8 @@ Public Class x265Params
     Sub ApplyPresetDefaultValues()
         AQmode.DefaultValue = 2
         AQStrength.DefaultValue = 1
+        CUtree.DefaultValue = True
+        Deblock.DefaultValue = True
         DeblockA.DefaultValue = 0
         DeblockB.DefaultValue = 0
         FrameThreads.DefaultValue = 0
@@ -1623,8 +1606,6 @@ Public Class x265Params
                 BAdapt.DefaultValue = 0
                 BFrames.DefaultValue = 3
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = False
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = True
                 FastIntra.DefaultValue = True
                 LimitRefs.DefaultValue = 0
@@ -1653,8 +1634,6 @@ Public Class x265Params
                 BAdapt.DefaultValue = 0
                 BFrames.DefaultValue = 3
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = False
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = True
                 FastIntra.DefaultValue = True
                 LimitRefs.DefaultValue = 0
@@ -1680,11 +1659,8 @@ Public Class x265Params
                 BAdapt.DefaultValue = 0
                 BFrames.DefaultValue = 4
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = False
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = True
                 FastIntra.DefaultValue = True
-                MaxCuSize.DefaultValue = 1
                 MaxMerge.DefaultValue = 2
                 MErange.DefaultValue = 57
                 RCLookahead.DefaultValue = 15
@@ -1706,8 +1682,6 @@ Public Class x265Params
                 BAdapt.DefaultValue = 0
                 BFrames.DefaultValue = 4
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = False
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = True
                 FastIntra.DefaultValue = True
                 MaxMerge.DefaultValue = 2
@@ -1728,11 +1702,9 @@ Public Class x265Params
             Case 4 'fast
                 [Me].DefaultValue = 1
                 AMP.DefaultValue = False
-                BAdapt.DefaultValue = 2
+                BAdapt.DefaultValue = 0
                 BFrames.DefaultValue = 4
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = False
                 FastIntra.DefaultValue = True
                 MaxMerge.DefaultValue = 2
@@ -1756,8 +1728,6 @@ Public Class x265Params
                 BAdapt.DefaultValue = 2
                 BFrames.DefaultValue = 4
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = True
                 FastIntra.DefaultValue = False
                 MaxMerge.DefaultValue = 2
@@ -1781,8 +1751,6 @@ Public Class x265Params
                 BAdapt.DefaultValue = 2
                 BFrames.DefaultValue = 4
                 BIntra.DefaultValue = False
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = False
                 FastIntra.DefaultValue = False
                 LimitModes.DefaultValue = True
@@ -1809,22 +1777,20 @@ Public Class x265Params
                 BAdapt.DefaultValue = 2
                 BFrames.DefaultValue = 8
                 BIntra.DefaultValue = True
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = False
                 FastIntra.DefaultValue = False
                 LimitModes.DefaultValue = True
                 LimitRefs.DefaultValue = 0
                 LimitTU.DefaultValue = 4
-                LookaheadSlices.DefaultValue = 4
-                MaxMerge.DefaultValue = 5
+                LookaheadSlices.DefaultValue = 1
+                MaxMerge.DefaultValue = 4
                 MErange.DefaultValue = 57
                 PsyRDOQ.DefaultValue = 1
                 RCLookahead.DefaultValue = 40
                 RD.DefaultValue = 6
                 rdoqLevel.DefaultValue = 2
                 Rect.DefaultValue = True
-                Ref.DefaultValue = 4
+                Ref.DefaultValue = 5
                 SAO.DefaultValue = True
                 Scenecut.DefaultValue = 40
                 SignHide.DefaultValue = True
@@ -1839,12 +1805,10 @@ Public Class x265Params
                 BAdapt.DefaultValue = 2
                 BFrames.DefaultValue = 8
                 BIntra.DefaultValue = True
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = False
                 FastIntra.DefaultValue = False
                 LimitTU.DefaultValue = 4
-                LookaheadSlices.DefaultValue = 4
+                LookaheadSlices.DefaultValue = 1
                 MaxMerge.DefaultValue = 4
                 MErange.DefaultValue = 57
                 PsyRDOQ.DefaultValue = 1
@@ -1867,12 +1831,10 @@ Public Class x265Params
                 BAdapt.DefaultValue = 2
                 BFrames.DefaultValue = 8
                 BIntra.DefaultValue = True
-                CUtree.DefaultValue = True
-                Deblock.DefaultValue = True
                 EarlySkip.DefaultValue = False
                 FastIntra.DefaultValue = False
                 LimitRefs.DefaultValue = 0
-                LookaheadSlices.DefaultValue = 0
+                LookaheadSlices.DefaultValue = 1
                 MaxMerge.DefaultValue = 5
                 MErange.DefaultValue = 92
                 RCLookahead.DefaultValue = 60
@@ -1901,6 +1863,7 @@ Public Class x265Params
                 AQStrength.Value = 0.0
                 PsyRD.Value = 0.0
                 PsyRDOQ.Value = 0.0
+                CUtree.Value = False
             Case 2 '"ssim"
                 AQmode.Value = 2
                 PsyRD.Value = 0.0
@@ -1935,7 +1898,7 @@ Public Class x265Params
                 Deblock.Value = True
                 DeblockA.Value = 1
                 DeblockB.Value = 1
-                BFrames.Value = 6
+                BFrames.Value += 2
         End Select
     End Sub
 
@@ -1949,6 +1912,7 @@ Public Class x265Params
                 AQStrength.DefaultValue = 0.0
                 PsyRD.DefaultValue = 0.0
                 PsyRDOQ.DefaultValue = 0.0
+                CUtree.DefaultValue = False
             Case 2 '"ssim"
                 AQmode.DefaultValue = 2
                 PsyRD.DefaultValue = 0.0
@@ -1980,8 +1944,10 @@ Public Class x265Params
             Case 6 '"Animation
                 PsyRD.DefaultValue = 0.4
                 AQStrength.DefaultValue = 0.4
-                Deblock.DefaultValue = False
-                BFrames.DefaultValue = 6
+                Deblock.DefaultValue = True
+                DeblockA.DefaultValue = 1
+                DeblockB.DefaultValue = 1
+                BFrames.DefaultValue += 2
         End Select
     End Sub
 

--- a/Encoding/x265Enc.vb
+++ b/Encoding/x265Enc.vb
@@ -892,7 +892,7 @@ Public Class x265Params
         .Switch = "--rskip",
         .Text = "Recursion Skip",
         .Expand = True,
-        .Options = {"Undefined", "0 - Disabled", "1 - RD Level 0-4 Neighbour costs and CU homogenity, RD Level 5-6 Comparison with inter2Nx2N", "2 - RD Level 0-6 CU edge denstiy"},
+        .Options = {"0 - Disabled", "1 - RD Level 0-4 Neighbour costs and CU homogenity, RD Level 5-6 Comparison with inter2Nx2N", "2 - RD Level 0-6 CU edge denstiy"},
         .Values = {"0", "1", "2"},
         .Init = 1}
 

--- a/Encoding/x265Enc.vb
+++ b/Encoding/x265Enc.vb
@@ -888,6 +888,14 @@ Public Class x265Params
         .Switches = {"-f"},
         .Text = "Frames"}
 
+    Property RSkip As New OptionParam With {
+        .Switch = "--rskip",
+        .Text = "Recursion Skip",
+        .Expand = True,
+        .Options = {"Undefined", "0 - Disabled", "1 - RD Level 0-4 Neighbour costs and CU homogenity, RD Level 5-6 Comparison with inter2Nx2N", "2 - RD Level 0-6 CU edge denstiy"},
+        .Values = {"0", "1", "2"},
+        .Init = 1}
+
     Overrides ReadOnly Property Items As List(Of CommandLineParam)
         Get
             If ItemsValue Is Nothing Then
@@ -906,18 +914,16 @@ Public Class x265Params
                     New OptionParam With {.Switch = "--refine-mv", .Text = "Refine MV", .Expand = True, .IntegerValue = True, .Options = {"Disabled", "Level 1: Search around scaled MV", "Level 2: Level 1 + Search around best AMVP cand", "Level 3: Level 2 + Search around the other AMVP cand"}},
                     New OptionParam With {.Switch = "--analysis-save-reuse-level", .Text = "Save Reuse Level", .Expand = True, .IntegerValue = True, .Options = {" 0 - Default", " 1 - Lookahead information", " 2 - Level 1 + intra/inter modes, ref's", " 3 - Level 1 + intra/inter modes, ref's", " 4 - Level 1 + intra/inter modes, ref's", " 5 - Level 2 + rect-amp", " 6 - Level 2 + rect-amp", " 7 - Level 5 + AVC size CU refinement", " 8 - Level 5 + AVC size Full CU analysis-info", " 9 - Level 5 + AVC size Full CU analysis-info", "10 - Level 5 + Full CU analysis-info"}},
                     New OptionParam With {.Switch = "--analysis-load-reuse-level", .Text = "Load Reuse Level", .Expand = True, .IntegerValue = True, .Options = {" 0 - Default", " 1 - Lookahead information", " 2 - Level 1 + intra/inter modes, ref's", " 3 - Level 1 + intra/inter modes, ref's", " 4 - Level 1 + intra/inter modes, ref's", " 5 - Level 2 + rect-amp", " 6 - Level 2 + rect-amp", " 7 - Level 5 + AVC size CU refinement", " 8 - Level 5 + AVC size Full CU analysis-info", " 9 - Level 5 + AVC size Full CU analysis-info", "10 - Level 5 + Full CU analysis-info"}},
-                    New OptionParam With {.Switch = "--rskip", .Text = "Recursion Skip", .Expand = True, .Options = {"Undefined", "0 - Disabled", "1 - RD Level 0-4 Neighbour costs, RD Level 5-6 Comparison with inter2Nx2N", "2 - RD Level 0-6 CU edge denstiy", "3 - RD Level 0-6 CU edge denstiy with forceful skip for lower levels of CTU"}, .Values = {"", "0", "1", "2", "3"}},
+                    RSkip,
+                    New NumParam With {.Switch = "--rskip-edge-threshold", .Text = "RSkip Edge Threshold, requires RSkip Mode 2", .Init = 5, .Config = {0, 100}},
                     MinCuSize, MaxCuSize, MaxTuSize, LimitRefs)
                 Add("Analysis 2",
                     New NumParam With {.Switch = "--analysis-reuse-level", .Text = "Refine Level", .Config = {1, 10}, .Init = 5},
                     New NumParam With {.Switch = "--scale-factor", .Text = "Scale Factor"},
-                    LimitTU,
-                    TUintra, TUinter, rdoqLevel,
-                    PsyRDOQ,
+                    LimitTU, TUintra, TUinter, rdoqLevel, PsyRDOQ,
                     New NumParam With {.Switch = "--dynamic-rd", .Text = "Dynamic RD", .Config = {0, 4}},
                     New NumParam With {.Switch = "--refine-intra", .Text = "Refine Intra", .Config = {0, 4}},
                     New NumParam With {.Switch = "--refine-inter", .Text = "Refine Inter", .Config = {0, 3}},
-                    New NumParam With {.Switch = "--rskip-edge-threshold", .Text = "RSkip Edge Threshold", .Init = 5, .Config = {0, 100}},
                     qpadaptationrange)
                 Add("Analysis 3", Rect, AMP,
                     New BoolParam With {.Switch = "--tskip", .Text = "Enable evaluation of transform skip coding for 4x4 TU coded blocks"},
@@ -1319,6 +1325,7 @@ Public Class x265Params
         PsyRD.Value = 2.0
         PsyRDOQ.Value = 0
         QComp.Value = 0.6
+        RSkip.Value = 1
 
         Select Case Preset.Value
             Case 0 'ultrafast
@@ -1566,6 +1573,7 @@ Public Class x265Params
                 rdoqLevel.Value = 2
                 Rect.Value = True
                 Ref.Value = 5
+                RSkip.Value = 0
                 SAO.Value = True
                 Scenecut.Value = 40
                 SignHide.Value = True
@@ -1596,6 +1604,7 @@ Public Class x265Params
         PsyRD.DefaultValue = 2.0
         PsyRDOQ.DefaultValue = 0
         QComp.DefaultValue = 0.6
+        RSkip.DefaultValue = 1
 
         Select Case Preset.Value
             Case 0 'ultrafast
@@ -1842,6 +1851,7 @@ Public Class x265Params
                 rdoqLevel.DefaultValue = 2
                 Rect.DefaultValue = True
                 Ref.DefaultValue = 5
+                RSkip.DefaultValue = 0
                 SAO.DefaultValue = True
                 Scenecut.DefaultValue = 40
                 SignHide.DefaultValue = True
@@ -1877,6 +1887,7 @@ Public Class x265Params
                 RcGrain.Value = True
                 PsyRD.Value = 4
                 PsyRDOQ.Value = 10
+                RSkip.Value = 0
                 SAO.Value = False
                 ConstVBV.Value = True
             Case 4 '"fastdecode"
@@ -1926,6 +1937,7 @@ Public Class x265Params
                 RcGrain.DefaultValue = True
                 PsyRD.DefaultValue = 4
                 PsyRDOQ.DefaultValue = 10
+                RSkip.DefaultValue = 0
                 SAO.DefaultValue = False
                 ConstVBV.DefaultValue = True
             Case 4 '"fastdecode"


### PR DESCRIPTION
Fixes Presets and Tunes for x265 encoder. 

Some values are fixed, biggest changes:

- b-frames in *Tune Animation* don't get a static value. According to the x265 docs b-frames should be "increased by 2".
- Introduced `RSkip` as Property and includes it in presets and tunes - options `Undefined` and `3` were removed
- Moved `--rskip-edge-threshold` NumParam from `Analysis 2` to `Analysis` next to `RSkip`