### PR TITLE
Skip running process

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,11 +8,12 @@
 - Include beta versions for update checker and show changelog (Dendraspis)
 - The final assistant tip supports SHIFT key to add the job at the top of the job list and
   CTRL to prevent showing the jobs dialog. Right-click shows a menu. (Dendraspis)
-- allow to open video files with relative paths on the command line (Dendraspis)
+- Allow to open video files with relative paths on the command line (Dendraspis)
 - Create F6 shortcut for Jobs button on Processing dialog (Dendraspis)
 - Create F7 shortcut for Log dialog
 - 4 commands added to open each source type separately (Dendraspis)
 - x265 Presets and Tunes fixes (Dendraspis)
+- The Processing dialog has a feature to skip the currently running job (Dendraspis)
 
 
 2.1.3.7 Beta

--- a/Forms/ProcessingForm.vb
+++ b/Forms/ProcessingForm.vb
@@ -216,6 +216,10 @@ Public Class ProcessingForm
         Dim cms As New ContextMenuStripEx(components)
         cms.Add("Suspend", AddressOf ProcController.Suspend)
         cms.Add("Resume", AddressOf ProcController.ResumeProcs)
+        cms.Add("-")
+        cms.Add("Abort", AddressOf Abort)
+        cms.Add("Skip", AddressOf Skip)
+        cms.Add("-")
         StopAfterCurrentJobMenuItem = cms.Add("Stop After Current Job", AddressOf StopAfterCurrentJob)
 
         bnMenu.ContextMenuStrip = cms
@@ -276,7 +280,15 @@ Public Class ProcessingForm
     End Sub
 
     Sub Abort()
-        ProcController.Abort()
+        If MsgOK("Abort processing?") Then
+            ProcController.Abort()
+        End If
+    End Sub
+
+    Sub Skip()
+        If MsgOK("Skip current process?") Then
+            ProcController.Skip()
+        End If
     End Sub
 
     Sub ShowForm()
@@ -309,9 +321,7 @@ Public Class ProcessingForm
     End Sub
 
     Sub bnAbort_Click(sender As Object, e As EventArgs) Handles bnAbort.Click
-        If MsgOK("Abort processing?") Then
-            Abort()
-        End If
+        Abort()
     End Sub
 
     Sub bnJobs_Click(sender As Object, e As EventArgs) Handles bnJobs.Click

--- a/Forms/ProcessingForm.vb
+++ b/Forms/ProcessingForm.vb
@@ -56,7 +56,7 @@ Public Class ProcessingForm
         Me.bnAbort.Name = "bnAbort"
         Me.bnAbort.Size = New System.Drawing.Size(260, 70)
         Me.bnAbort.TabIndex = 2
-        Me.bnAbort.Text = "Abort"
+        Me.bnAbort.Text = "Abort (ESC)"
         '
         'laWhenfinisheddo
         '
@@ -200,6 +200,7 @@ Public Class ProcessingForm
 
     Private TaskbarButtonCreatedMessage As Integer
     Private StopAfterCurrentJobMenuItem As ActionMenuItem
+    Private CMS As ContextMenuStripEx
 
     Property Taskbar As Taskbar
 
@@ -213,16 +214,20 @@ Public Class ProcessingForm
         TaskbarButtonCreatedMessage = Native.RegisterWindowMessage("TaskbarButtonCreated")
         ScaleClientSize(45, 28)
 
-        Dim cms As New ContextMenuStripEx(components)
-        cms.Add("Suspend", AddressOf ProcController.Suspend)
-        cms.Add("Resume", AddressOf ProcController.ResumeProcs)
-        cms.Add("-")
-        cms.Add("Abort", AddressOf Abort)
-        cms.Add("Skip", AddressOf Skip)
-        cms.Add("-")
-        StopAfterCurrentJobMenuItem = cms.Add("Stop After Current Job", AddressOf StopAfterCurrentJob)
+        CMS = New ContextMenuStripEx(components)
+        CMS.Add("Suspend", AddressOf ProcController.Suspend, "Suspends the current process, might not work with all tools.")
+        CMS.Add("Resume", AddressOf ProcController.ResumeProcs, "Resumes a suspended process.")
+        CMS.Add("-")
+        CMS.Add("Abort", AddressOf Abort, "Aborts all job processing of this StaxRip instance.").ShortcutKeyDisplayString = "ESC" + g.MenuSpace
+        CMS.Add("Skip", AddressOf Skip, "Aborts the current job and continues with the next job.")
+        StopAfterCurrentJobMenuItem = CMS.Add("Stop After Current", AddressOf StopAfterCurrentJob, "Stops all job processing after the current job.")
+        CMS.Add("-")
+        CMS.Add("Jobs", AddressOf JobsForm.ShowForm, "Shows the Jobs dialog.").ShortcutKeyDisplayString = "F6" + g.MenuSpace
+        CMS.Add("Log", AddressOf g.DefaultCommands.ShowLogFile, "Shows the Jobs dialog.").ShortcutKeyDisplayString = "F7" + g.MenuSpace
+        CMS.Add("-")
+        CMS.Add("Help", AddressOf ShowHelp).ShortcutKeyDisplayString = "F1" + g.MenuSpace
 
-        bnMenu.ContextMenuStrip = cms
+        bnMenu.ContextMenuStrip = CMS
     End Sub
 
     Protected Overrides Sub WndProc(ByRef m As Message)
@@ -335,8 +340,24 @@ Public Class ProcessingForm
     Protected Overrides Sub OnKeyUp(e As KeyEventArgs)
         MyBase.OnKeyUp(e)
 
-        If e.KeyData = Keys.F6 Then
-            JobsForm.ShowForm()
-        End If
+        Select Case e.KeyData
+            Case Keys.F6
+                JobsForm.ShowForm()
+            Case Keys.F7
+                g.DefaultCommands.ShowLogFile()
+            Case Keys.Escape
+                Abort()
+        End Select
+    End Sub
+
+    Sub ProcessingForm_HelpRequested(sender As Object, e As HelpEventArgs) Handles Me.HelpRequested
+        ShowHelp()
+    End Sub
+
+    Sub ShowHelp()
+        Dim form As New HelpForm()
+        form.Doc.WriteStart(Text)
+        form.Doc.WriteTips(CMS.GetTips)
+        form.Show()
     End Sub
 End Class

--- a/General/General.vb
+++ b/General/General.vb
@@ -826,6 +826,10 @@ Public Class AbortException
     Inherits ApplicationException
 End Class
 
+Public Class SkipException
+    Inherits ApplicationException
+End Class
+
 Public Class CLIArg
     Sub New(value As String)
         Me.Value = value

--- a/General/GlobalClass.vb
+++ b/General/GlobalClass.vb
@@ -344,7 +344,7 @@ Public Class GlobalClass
             If jobPath.StartsWith(Folder.Settings + "Batch Projects\") Then
                 File.Delete(jobPath)
             End If
-        Catch ex As TaskCanceledException
+        Catch ex As SkipException
             Log.Save()
             ProcController.Aborted = False
         Catch ex As ErrorAbortException

--- a/General/GlobalClass.vb
+++ b/General/GlobalClass.vb
@@ -344,6 +344,9 @@ Public Class GlobalClass
             If jobPath.StartsWith(Folder.Settings + "Batch Projects\") Then
                 File.Delete(jobPath)
             End If
+        Catch ex As TaskCanceledException
+            Log.Save()
+            ProcController.Aborted = False
         Catch ex As ErrorAbortException
             Log.Save()
             g.ShowException(ex, Nothing, Nothing, 50)

--- a/General/Proc.vb
+++ b/General/Proc.vb
@@ -227,33 +227,8 @@ Public Class Proc
         LogItems.Add(value)
     End Sub
 
-    Sub KillAndThrow()
+    Sub Kill()
         Try
-            Abort = True
-
-            If Not Process.HasExited Then
-                If Process.ProcessName = "cmd" Then
-                    For Each i In ProcessHelp.GetChilds(Process)
-                        If {"conhost", "vspipe", "avs2pipemod64"}.Contains(i.ProcessName) Then
-                            Continue For
-                        End If
-
-                        If Not i.HasExited Then
-                            i.Kill()
-                        End If
-                    Next
-                Else
-                    Process.Kill()
-                End If
-            End If
-        Catch
-        End Try
-    End Sub
-
-    Sub KillAndSkip()
-        Try
-            Skip = True
-
             If Not Process.HasExited Then
                 If Process.ProcessName = "cmd" Then
                     For Each i In ProcessHelp.GetChilds(Process)
@@ -334,7 +309,7 @@ Public Class Proc
             End If
         Catch ex As AbortException
             Throw ex
-        Catch ex As TaskCanceledException
+        Catch ex As SkipException
             Throw ex
         Catch ex As Exception
             Dim msg = ex.Message
@@ -367,7 +342,7 @@ Public Class Proc
                 End If
 
                 If Skip Then
-                    Throw New TaskCanceledException
+                    Throw New SkipException
                 End If
 
                 If AllowedExitCodes.Length > 0 AndAlso Not AllowedExitCodes.Contains(ExitCode) Then
@@ -408,7 +383,7 @@ Public Class Proc
         End If
 
         If Skip Then
-            Throw New TaskCanceledException
+            Throw New SkipException
         End If
     End Sub
 

--- a/General/ProcController.vb
+++ b/General/ProcController.vb
@@ -213,6 +213,12 @@ Public Class ProcController
         Next
     End Sub
 
+    Shared Sub Skip()
+        For Each i In Procs.ToArray
+            i.Proc.KillAndSkip()
+        Next
+    End Sub
+
     Shared Sub Suspend()
         For Each process In GetProcesses()
             For Each thread As ProcessThread In process.Threads
@@ -278,7 +284,7 @@ Public Class ProcController
             End If
         End SyncLock
 
-        If Not Proc.Succeeded Then
+        If Not Proc.Succeeded And Not Proc.Skip Then
             Abort()
         End If
 

--- a/General/ProcController.vb
+++ b/General/ProcController.vb
@@ -209,13 +209,15 @@ Public Class ProcController
         Registry.CurrentUser.Write("Software\" + Application.ProductName, "ShutdownMode", 0)
 
         For Each i In Procs.ToArray
-            i.Proc.KillAndThrow()
+            i.Proc.Abort = True
+            i.Proc.Kill()
         Next
     End Sub
 
     Shared Sub Skip()
         For Each i In Procs.ToArray
-            i.Proc.KillAndSkip()
+            i.Proc.Skip = True
+            i.Proc.Kill()
         Next
     End Sub
 
@@ -367,10 +369,13 @@ Public Class ProcController
 
         SyncLock Procs
             If g.ProcForm Is Nothing Then
-                Task.Run(Sub()
-                             g.ProcForm = New ProcessingForm
-                             Application.Run(g.ProcForm)
-                         End Sub)
+                Dim thread = New Thread(Sub()
+                                            g.ProcForm = New ProcessingForm
+                                            Application.Run(g.ProcForm)
+                                        End Sub)
+
+                thread.SetApartmentState(ApartmentState.STA)
+                thread.Start()
 
                 While Not ProcessingForm.WasHandleCreated
                     Thread.Sleep(50)


### PR DESCRIPTION
I think this screenshots explains everything:
![StaxRipSKIP](https://user-images.githubusercontent.com/50659978/88487390-ec945c00-cf84-11ea-9310-e587f27c07df.JPG)

There are two things I wanna point on:
- I extended the context menu with *Skip* **and *Abort*** for the sake of completeness and didn't touch the *Abort* button. Personally I would remove the *Abort* button, but it's up to you which combination you wanna use/add.
- I tried to implement the *Skip* feature based on your implementation of the *Abort* process. Therefore I used `TaskCancelledException`, because it kind of fits and I didn't want to create a custom/derived exception for only that purpose. Feel free to change it if it bothers you.  🙂 

Hope I didn't forget any aspect of skipping these (very) complex processes. In my little test cases it worked great.