### PR TITLE
Fix incorrect GradFun2DBmod Web address

### DIFF
--- a/General/Package.vb
+++ b/General/Package.vb
@@ -1327,7 +1327,7 @@ Public Class Package
             .Location = "Plugins\AVS\GradFun2DB",
             .Filename = "GradFun2DBmod.avsi",
             .HelpFilename = "Readme.txt",
-            .WebURL = "http://avisynth.nl/index.php/GradFun2dbmod",
+            .WebURL = "http://avisynth.nl/index.php/GradFun2DBmod",
             .Description = "An advanced debanding script based on GradFun2DB.",
             .AvsFilterNames = {"GradFun2DBmod"}})
 

--- a/docs/generated/tools.rst
+++ b/docs/generated/tools.rst
@@ -1304,7 +1304,7 @@ An advanced debanding script based on GradFun2DB.
 
 Filters: GradFun2DBmod
 
-http://avisynth.nl/index.php/GradFun2dbmod
+http://avisynth.nl/index.php/GradFun2DBmod
 
 
 HQDeringmod


### PR DESCRIPTION
To http://avisynth.nl/index.php/GradFun2DBmod

![StaxRip_2 1 8 2_incorrect_GradFun2DBmod_Web_address_20210221](https://user-images.githubusercontent.com/3157518/108639737-e26b0b00-744a-11eb-8428-df96733dd4fb.jpg)
