### PR TITLE
SMDegrain: reinstate contrasharp true parameter

### DIFF
--- a/General/Package.vb
+++ b/General/Package.vb
@@ -775,9 +775,9 @@ Public Class Package
         .Description = "SMDegrain, the Simple MDegrain Mod, is mainly a convenience function for using MVTools.",
         .AvsFilterNames = {"SMDegrain"},
         .AvsFiltersFunc = Function() {
-            New VideoFilter("Noise", "SMDegrain | SMDegrain Light Grain", "SMDegrain(tr=1,thSAD=300)"),
+            New VideoFilter("Noise", "SMDegrain | SMDegrain Light Grain", "SMDegrain(tr=1, thSAD=300, contrasharp=true)"),
             New VideoFilter("Noise", "SMDegrain | SMDegrain MDegrain2", "super_search = Dither_Luma_Rebuild(S0=1.0, c=0.0625).MSuper(rfilter=4)" + BR + "bv2 = super_search.MAnalyse(isb=true,  delta=2, overlap=4)" + BR + "bv1 = super_search.MAnalyse(isb=true,  delta=1, overlap=4)" + BR + "fv1 = super_search.MAnalyse(isb=false, delta=1, overlap=4)" + BR + "fv2 = super_search.MAnalyse(isb=false, delta=2, overlap=4)" + BR + "MDegrain2(MSuper(levels=1), bv1, fv1, bv2, fv2, thSAD=300, thSADC=150)"),
-            New VideoFilter("Noise", "SMDegrain | SMDegrain Hard Grain", "SMDegrain(tr=6,thSAD=600,refinemotion=true)")}})
+            New VideoFilter("Noise", "SMDegrain | SMDegrain Hard Grain", "SMDegrain(tr=6, thSAD=600, contrasharp=true, refinemotion=true)")}})
 
     Shared Property Zs_RF_Shared As Package = Add(New PluginPackage With {
         .Name = "Zs_RF_Shared",


### PR DESCRIPTION
Underlying filters have been updated, so contrasharp=true parameter is working now.