### PR TITLE
Fix typo and copyright date in License

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,10 +1,10 @@
 
 MIT License
 
-Copyright (C) 2002-2020 StaxRip authors
+Copyright (C) 2002-2021 StaxRip authors
 
 Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and ssociated documentation files (the "Software"),
+a copy of this software and associated documentation files (the "Software"),
 to deal in the Software without restriction, including without limitation
 the rights to use, copy, modify, merge, publish, distribute, sublicense,
 and/or sell copies of the Software, and to permit persons to whom the


### PR DESCRIPTION
Typo: "association" was missing first letter, copyright year was still 2020.