### PR TITLE
Set initial Shutdow Timeout to 90 seconds

### DIFF
--- a/Source/General/ApplicationSettings.vb
+++ b/Source/General/ApplicationSettings.vb
@@ -71,7 +71,7 @@ Public Class ApplicationSettings
     Public ShowPreviewInfo As Boolean
     Public ShowTemplateSelection As Boolean
     Public ShutdownForce As Boolean
-    Public ShutdownTimeout As Integer
+    Public ShutdownTimeout As Integer = 90
     Public StartupTemplate As String
     Public Storage As ObjectStorage
     Public StringDictionary As Dictionary(Of String, String)


### PR DESCRIPTION
This allows post processing tasks like thumbnail creation to be able to complete before shutdown happens.