### PR TITLE
Fix audio (and subtitle) cutting issues caused by ffmpeg upstream

### DIFF
--- a/Source/General/Audio.vb
+++ b/Source/General/Audio.vb
@@ -621,7 +621,7 @@ Public Class Audio
         Dim aviPath = p.TempDir + base + "_cut_.avi"
         Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
         Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-        Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v copy " + aviPath.Escape
+        Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
         Using proc As New Proc
             proc.Header = "Create avi file for audio cutting " & (ap.GetTrackIndex + 1)

--- a/Source/General/Audio.vb
+++ b/Source/General/Audio.vb
@@ -621,7 +621,7 @@ Public Class Audio
         Dim aviPath = p.TempDir + base + "_cut_.avi"
         Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
         Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-        Dim args = $"-f lavfi -i color=c=black:s=2x2:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
+        Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
         Using proc As New Proc
             proc.Header = "Create avi file for audio cutting " & (ap.GetTrackIndex + 1)

--- a/Source/General/Audio.vb
+++ b/Source/General/Audio.vb
@@ -621,7 +621,7 @@ Public Class Audio
         Dim aviPath = p.TempDir + base + "_cut_.avi"
         Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
         Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-        Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
+        Dim args = $"-f lavfi -i color=c=black:s=2x2:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
         Using proc As New Proc
             proc.Header = "Create avi file for audio cutting " & (ap.GetTrackIndex + 1)

--- a/Source/General/Misc.vb
+++ b/Source/General/Misc.vb
@@ -1457,7 +1457,7 @@ Public Class Subtitle
             Dim aviPath = p.TempDir + inSub.Path.Base + "_cut_mm.avi"
             Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
             Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-            Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
+            Dim args = $"-f lavfi -i color=c=black:s=2x2:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
             Using proc As New Proc
                 proc.Header = "Create avi file for subtitle cutting"

--- a/Source/General/Misc.vb
+++ b/Source/General/Misc.vb
@@ -1457,7 +1457,7 @@ Public Class Subtitle
             Dim aviPath = p.TempDir + inSub.Path.Base + "_cut_mm.avi"
             Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
             Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-            Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v copy " + aviPath.Escape
+            Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
             Using proc As New Proc
                 proc.Header = "Create avi file for subtitle cutting"

--- a/Source/General/Misc.vb
+++ b/Source/General/Misc.vb
@@ -1457,7 +1457,7 @@ Public Class Subtitle
             Dim aviPath = p.TempDir + inSub.Path.Base + "_cut_mm.avi"
             Dim d = (p.CutFrameCount / p.CutFrameRate).ToString("f9", CultureInfo.InvariantCulture)
             Dim r = p.CutFrameRate.ToString("f9", CultureInfo.InvariantCulture)
-            Dim args = $"-f lavfi -i color=c=black:s=2x2:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
+            Dim args = $"-f lavfi -i color=c=black:s=16x16:d={d}:r={r} -y -hide_banner -c:v ffv1 -g 1 " + aviPath.Escape
 
             Using proc As New Proc
                 proc.Header = "Create avi file for subtitle cutting"


### PR DESCRIPTION
Closes #997 

Tested and confirmed working by manually performing the commands StaxRip uses to create the dummy/filler file and perform the subsequent cut.