### PR TITLE
FrameServer: validate string conversions

### DIFF
--- a/Source/FrameServer/Common.cpp
+++ b/Source/FrameServer/Common.cpp
@@ -1,38 +1,83 @@
 
 #include "Common.h"
 
+#include <limits>
+
+namespace
+{
+    int GetWindowsStringLength(std::size_t length)
+    {
+        if (length > static_cast<std::size_t>((std::numeric_limits<int>::max)()))
+            throw std::length_error("String exceeds the Windows conversion limit");
+
+        return static_cast<int>(length);
+    }
+
+    std::string ConvertWideToMultiByte(const std::wstring& source, UINT codePage)
+    {
+        if (source.empty())
+            return {};
+
+        const int sourceLength = GetWindowsStringLength(source.length());
+        const int outputLength = WideCharToMultiByte(
+            codePage, 0, source.data(), sourceLength, nullptr, 0, nullptr, nullptr);
+
+        if (outputLength == 0)
+            throw std::runtime_error("WideCharToMultiByte failed");
+
+        std::string output(outputLength, 0);
+        const int convertedLength = WideCharToMultiByte(
+            codePage, 0, source.data(), sourceLength, output.data(), outputLength, nullptr, nullptr);
+
+        if (convertedLength != outputLength)
+            throw std::runtime_error("WideCharToMultiByte returned an unexpected length");
+
+        return output;
+    }
+
+    std::wstring ConvertMultiByteToWide(const std::string& source, UINT codePage)
+    {
+        if (source.empty())
+            return {};
+
+        const int sourceLength = GetWindowsStringLength(source.length());
+        const int outputLength = MultiByteToWideChar(
+            codePage, 0, source.data(), sourceLength, nullptr, 0);
+
+        if (outputLength == 0)
+            throw std::runtime_error("MultiByteToWideChar failed");
+
+        std::wstring output(outputLength, 0);
+        const int convertedLength = MultiByteToWideChar(
+            codePage, 0, source.data(), sourceLength, output.data(), outputLength);
+
+        if (convertedLength != outputLength)
+            throw std::runtime_error("MultiByteToWideChar returned an unexpected length");
+
+        return output;
+    }
+}
+
 ///////////////////// convert strings
 
 std::string ConvertWideToANSI(const std::wstring& wstr)
 {
-    int count = WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), wstr.length(), NULL, 0, NULL, NULL);
-    std::string str(count, 0);
-    WideCharToMultiByte(CP_ACP, 0, wstr.c_str(), -1, &str[0], count, NULL, NULL);
-    return str;
+    return ConvertWideToMultiByte(wstr, CP_ACP);
 }
 
 std::wstring ConvertAnsiToWide(const std::string& str)
 {
-    int count = MultiByteToWideChar(CP_ACP, 0, str.c_str(), str.length(), NULL, 0);
-    std::wstring wstr(count, 0);
-    MultiByteToWideChar(CP_ACP, 0, str.c_str(), str.length(), &wstr[0], count);
-    return wstr;
+    return ConvertMultiByteToWide(str, CP_ACP);
 }
 
 std::string ConvertWideToUtf8(const std::wstring& wstr)
 {
-    int count = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), wstr.length(), NULL, 0, NULL, NULL);
-    std::string str(count, 0);
-    WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &str[0], count, NULL, NULL);
-    return str;
+    return ConvertWideToMultiByte(wstr, CP_UTF8);
 }
 
 std::wstring ConvertUtf8ToWide(const std::string& str)
 {
-    int count = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), NULL, 0);
-    std::wstring wstr(count, 0);
-    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), &wstr[0], count);
-    return wstr;
+    return ConvertMultiByteToWide(str, CP_UTF8);
 }
 
 //////////////////// Misc
@@ -41,9 +86,12 @@ std::string GetWinErrorMessage(int id)
 {
     std::string ret(2048, 0);
 
-    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-        NULL, id, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-        (LPSTR)ret.c_str(), ret.capacity(), NULL);
+    const DWORD length = FormatMessageA(
+        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, static_cast<DWORD>(id), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        ret.data(), static_cast<DWORD>(ret.size()), nullptr);
+
+    ret.resize(length);
 
     return ret;
 }


### PR DESCRIPTION
## Summary
- use checked `int` lengths for Win32 string conversion calls
- use the same explicit source length for sizing and conversion
- reject failed or inconsistent conversion results
- return Windows error messages at their actual length instead of with NUL padding

## Root cause
The wide-to-multibyte helpers sized output with an explicit source length, then converted with `-1`. The second call therefore also required room for a terminator. On the tested Windows SDK it returned 0 with `ERROR_INSUFFICIENT_BUFFER`, while the code consumed bytes left in the output buffer. The helpers also narrowed `size_t` implicitly, and `GetWinErrorMessage` returned its entire fixed buffer.

## Impact
Valid ANSI and UTF-8 conversions keep their payload. Embedded NULs are preserved because both calls now use the same explicit length. Inputs larger than the Win32 `int` limit fail explicitly. Windows error messages no longer carry unused NUL padding.

## Validation
- differential x64 probe: unchanged v2.52.5 failed; this branch passed ASCII, Unicode, embedded-NUL, empty-input, and error-length cases
- probe compiled with MSVC 14.44 at `/W4` with zero warnings
- FrameServer `Debug|x64`: passed, zero warnings
- FrameServer `Release|x64`: passed; only the three existing VapourSynth narrowing warnings remain
- `StaxRip.sln` `Debug|x64`: passed, zero warnings
- `StaxRip.sln` `Release|x64`: passed; only the same three existing VapourSynth warnings remain

## Follow-up integrated validation
This commit was later included in a portable x64 candidate with other independently proposed changes:

- Debug and Release x64 solution builds passed with zero warnings and errors
- the full GUI started, dismissed its owned changelog window, and opened four synthetic media fixtures
- ten AviSynth and VapourSynth cases passed with bundled filters and representative media
- 5,000 create/open/read/release cycles per engine passed with zero net handle growth
- a 3,928-file release-equivalent archive passed integrity and exact manifest checks

These results cover ordinary runtime use of the conversion paths. The differential probe remains the exact evidence for embedded NULs, failed conversion calls, and inputs above the Win32 `int` limit.

## Limits and review notes
- the follow-up runtime and packaging results came from an integrated candidate, not this isolated branch
- x86 is unsupported and was not exercised
- `Source/BuildAndPack.ps1` and `Source/Release.ps1` were not invoked; their relevant copy, exclusion, and archive behavior was reproduced in an isolated scratch directory
- arbitrary user media, third-party plugins and scripts, hardware encoders, multi-hour jobs, and live update or release publication were not tested
- the FrameServer native-boundary approval was explicitly granted for this work
- no logging, persisted data, command generation, dependency, project, or ABI layout changed