### PR TITLE
FrameServer: reject overflowing VapourSynth metadata

### DIFF
--- a/Source/FrameServer/VapourSynthServer.cpp
+++ b/Source/FrameServer/VapourSynthServer.cpp
@@ -1,6 +1,18 @@
 
 #include "VapourSynthServer.h"
 
+#include <limits>
+
+namespace
+{
+    template <typename T>
+    bool FitsFrameServerInt(T value)
+    {
+        return value >= static_cast<T>((std::numeric_limits<int>::min)()) &&
+            value <= static_cast<T>((std::numeric_limits<int>::max)());
+    }
+}
+
 void logMessageHandler(int msgType, const char* msg, void* userData)
 {
     if (msgType > mtWarning) {
@@ -109,8 +121,12 @@ HRESULT __stdcall VapourSynthServer::OpenFile(WCHAR* file)
         m_Info.Width = m_vsInfo->width;
         m_Info.Height = m_vsInfo->height;
         m_Info.FrameCount = m_vsInfo->numFrames;
-        m_Info.FrameRateNum = m_vsInfo->fpsNum;
-        m_Info.FrameRateDen = m_vsInfo->fpsDen;
+
+        if (!FitsFrameServerInt(m_vsInfo->fpsNum) || !FitsFrameServerInt(m_vsInfo->fpsDen))
+            throw std::runtime_error("VapourSynth frame rate exceeds the FrameServer integer range");
+
+        m_Info.FrameRateNum = static_cast<int>(m_vsInfo->fpsNum);
+        m_Info.FrameRateDen = static_cast<int>(m_vsInfo->fpsDen);
 
         const VSVideoFormat format = m_vsInfo->format;
         int id = m_vsAPI->queryVideoFormatID(format.colorFamily, format.sampleType, format.bitsPerSample, format.subSamplingW, format.subSamplingH, m_vsCore);
@@ -190,7 +206,18 @@ HRESULT __stdcall VapourSynthServer::GetFrame(int position, void** data, int& pi
         return E_FAIL;
     }
     
-    pitch = m_vsAPI->getStride(frame, 0);
+    const ptrdiff_t frameStride = m_vsAPI->getStride(frame, 0);
+
+    if (!FitsFrameServerInt(frameStride))
+    {
+        m_Error = L"VapourSynth frame stride exceeds the FrameServer integer range";
+        *data = nullptr;
+        pitch = 0;
+        m_vsAPI->freeFrame(frame);
+        return E_FAIL;
+    }
+
+    pitch = static_cast<int>(frameStride);
 
     if (m_vsFrame)
         m_vsAPI->freeFrame(m_vsFrame);


### PR DESCRIPTION
## Summary
- keep the existing 32-bit FrameServer ABI unchanged
- reject VapourSynth frame-rate components that do not fit that ABI
- reject an unrepresentable frame stride before returning it to managed bitmap code
- clear frame outputs and free the newly acquired frame on stride-range failure

## Root cause
VapourSynth R79 exposes `fpsNum` and `fpsDen` as `int64_t` and frame stride as `ptrdiff_t`. StaxRip's native COM structure and managed declarations use 32-bit integers. Direct assignment on the x64 target wraps values above `Int32.MaxValue` negative.

## Impact
Representable metadata and ordinary frames keep the same ABI and behavior. An unrepresentable frame-rate ratio now makes `OpenFile` return `E_FAIL` with a fixed error. An unrepresentable stride makes `GetFrame` return `E_FAIL`, clears the pointer and pitch, and frees the temporary frame instead of publishing a negative pitch.

## Validation
A controlled x64 fake `VSScript.dll` exercised the built `FrameServer.dll` in separate processes:

- normal metadata and stride: success, pitch 8, held frame freed once on server release
- frame-rate component `2147483648`: `OpenFile` returned `E_FAIL`
- stride `2147483648`: `GetFrame` returned `E_FAIL`, pointer was null, pitch was 0, and the acquired frame was freed once

The same harness against unchanged v2.52.5 accepted both overflow cases and produced negative 32-bit values.

Build gates:

- FrameServer `Debug|x64`: passed, zero warnings
- FrameServer `Release|x64`: passed; the three VapourSynth narrowing warnings are gone
- `StaxRip.sln` `Debug|x64`: passed, zero warnings
- `StaxRip.sln` `Release|x64`: passed; only seven existing `Common.cpp` warnings remain, addressed independently by #1987

## Follow-up integrated validation
This commit was later included in a portable x64 candidate with other independently proposed changes:

- packaged VapourSynth R73 and an R79 compatibility runtime passed normal metadata, first/middle/last frame reads, invalid scripts, sequential servers, and overlapping servers
- the full GUI opened four synthetic media fixtures
- ten AviSynth and VapourSynth bundled-filter and media cases passed
- 5,000 create/open/read/release cycles per engine passed with zero net handle growth
- a 3,928-file release-equivalent archive passed integrity and exact manifest checks

The real runtimes validate representable metadata and ordinary frame handling. The oversized frame-rate and stride rejection branches still require the controlled fake API because practical real-runtime fixtures do not expose those values.

## Limits and review notes
- the overflow activation harness used a controlled fake API; real-runtime checks covered only representable values
- the follow-up runtime and packaging results came from an integrated candidate, not this isolated branch
- x86 is unsupported and was not exercised
- `Source/BuildAndPack.ps1` and `Source/Release.ps1` were not invoked; their relevant copy, exclusion, and archive behavior was reproduced in an isolated scratch directory
- arbitrary user media, third-party plugins and scripts, hardware encoders, multi-hour jobs, and live update or release publication were not tested
- the FrameServer native ABI and frame-ownership approval was explicitly granted for this work
- no structure layout, managed declaration, logging, persisted data, command generation, or dependency changed