### PR TITLE
FrameServer: keep x64 intermediates in the ignored tree

### DIFF
--- a/Source/FrameServer/FrameServer.vcxproj
+++ b/Source/FrameServer/FrameServer.vcxproj
@@ -76,6 +76,7 @@
     <OutDir>..\bin\</OutDir>
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
@@ -89,6 +90,7 @@
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>..\bin\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>


### PR DESCRIPTION
## Summary

- set the FrameServer intermediate directory explicitly for Debug x64 and Release x64
- match the existing Win32 layout and the existing `Source/FrameServer/x64` ignore rule
- leave final outputs, toolchain settings, solution mappings, and `.gitignore` unchanged

## Root cause

Without an x64 `IntDir`, current MSBuild evaluates the default as `FrameServer\x64\<Configuration>\` relative to the project directory. Builds therefore create an untracked `Source/FrameServer/FrameServer/x64` tree. Both Win32 configurations already set `IntDir` to `$(Platform)\$(Configuration)\`, and the resulting direct platform tree is already ignored.

## Impact

Debug x64 and Release x64 compiler intermediates now stay under `Source/FrameServer/x64/<Configuration>`. `FrameServer.dll` still targets `Source/bin`.

## Validation

- XML parse: passed
- evaluated Debug x64 `IntDir`: `x64\Debug\`
- evaluated Release x64 `IntDir`: `x64\Release\`
- FrameServer Debug x64 rebuild: passed with zero warnings and zero errors
- FrameServer Release x64 rebuild: passed with ten existing conversion warnings and zero errors; those warnings are addressed independently by #1987 and #1988
- the old nested `Source/FrameServer/FrameServer` directory was absent after both builds
- the direct Debug and Release intermediate paths matched the existing `.gitignore` rule
- final patch: one project file, two added elements

## Follow-up integrated validation

This commit was later included in a portable x64 candidate with other independently proposed changes:

- Debug and Release x64 solution builds passed with zero warnings and errors
- the full GUI started and opened four synthetic media fixtures
- ten AviSynth and VapourSynth cases passed
- 5,000 create/open/read/release cycles per engine passed with zero net handle growth
- a 3,928-file release-equivalent archive passed integrity and exact manifest checks

The isolated branch checks remain the direct evidence for the evaluated intermediate paths and the absence of the old nested build directory.

## Limits and review notes

- the follow-up runtime and packaging results came from an integrated candidate, not this isolated branch
- x86 is unsupported and was not exercised; this patch did not change the existing Win32 `IntDir` pattern
- `Source/BuildAndPack.ps1` and `Source/Release.ps1` were not invoked; their relevant copy, exclusion, and archive behavior was reproduced in an isolated scratch directory
- arbitrary user media, third-party plugins and scripts, hardware encoders, multi-hour jobs, and live update or release publication were not tested
- no source code, ABI, dependency, logging, persisted data, documentation, or release contents changed
- the build-configuration approval gate was explicitly approved for this change