### PR TITLE
Updater: remove unused architecture argument

### DIFF
--- a/Source/Forms/MainForm.vb
+++ b/Source/Forms/MainForm.vb
@@ -6073,7 +6073,7 @@ Partial Public Class MainForm
         ProcessCommandLine(Environment.CommandLine)
         StaxRipUpdate.SetFirstRunOnCurrentVersion()
         StaxRipUpdate.ShowUpdateQuestion()
-        StaxRipUpdate.CheckForUpdateAsync(False, Environment.Is64BitProcess)
+        StaxRipUpdate.CheckForUpdateAsync(False)
         g.RunTask(AddressOf g.LoadPowerShellScripts)
         'Text = $"{Size.Width}x{Size.Height}"
     End Sub

--- a/Source/General/GlobalCommands.vb
+++ b/Source/General/GlobalCommands.vb
@@ -14,7 +14,7 @@ Imports StaxRip.UI
 Public Class GlobalCommands
     <Command("Checks if an update is available.")>
     Sub CheckForUpdate()
-        StaxRipUpdate.CheckForUpdateAsync(True, Environment.Is64BitProcess)
+        StaxRipUpdate.CheckForUpdateAsync(True)
     End Sub
 
     <Command("Shows the log file with the built-in log file viewer.")>

--- a/Source/General/StaxRipUpdate.vb
+++ b/Source/General/StaxRipUpdate.vb
@@ -38,7 +38,7 @@ Public Class StaxRipUpdate
         End If
     End Sub
 
-    Shared Async Sub CheckForUpdateAsync(Optional force As Boolean = False, Optional x64 As Boolean = True)
+    Shared Async Sub CheckForUpdateAsync(Optional force As Boolean = False)
         If g.IsSupporterRelease Then Exit Sub
         If Not s.CheckForUpdates AndAlso Not force Then Exit Sub
 


### PR DESCRIPTION
`StaxRipUpdate.CheckForUpdateAsync` took an `x64` parameter that was never read. Both callers passed `Environment.Is64BitProcess`. This removes the parameter and the two arguments.

StaxRip builds x64 only, and the updater's release-asset pattern already matches `-x64` archives exclusively, so the argument implied an architecture-dependent selection path that does not exist.

Signature cleanup only. Update timing, network requests, asset matching, version comparison, dismiss state, and dialogs are unchanged.

Checked `rg -n "CheckForUpdateAsync" Source` for remaining call sites, and built StaxRip Debug and Release x64. A live GitHub update request and its dialog flow were not exercised. Retiring the other legacy x86 project and runtime paths is deliberately not part of this change.
