### PR TITLE
Issues: clarify log attachment privacy

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -52,4 +52,5 @@ body:
       label: Additional information
       description: |
         Add any other context about the problem here.
-        If applicable, add screenshots to help explain your problem and/or provide a log file. The log file is located in the temp folder and the temp folder is located in the same directory as the source file. The log file ends with _staxrip.log.
+        If applicable, add screenshots or a log file. To export a safer log, open Project > Log File, right-click the log, and select Save Obfuscated As.
+        Review the saved file before attaching it. Obfuscation changes the current source path and name, but other paths, scripts, command lines, and system details may remain.


### PR DESCRIPTION
The bug-report form pointed reporters at the raw job log. StaxRip logs can contain file paths, scripts, command lines, media details, external-tool output, and system information.

The form now points at the existing `Save Obfuscated As` action instead, and asks reporters to review the exported file before attaching it. That export replaces the current source path and base name, but it does not remove every private value, which is why the review step is spelled out rather than implied.

Issue-template text only. Runtime logging, log paths, history retention, and both export actions are unchanged.

Checked by parsing the form with PyYAML and confirming the same seven fields and IDs survive, plus `git diff --check`. A synthetic redaction probe confirmed the behaviour described above: the current source path and base name were replaced, while an unrelated target path and a machine detail were retained. No application runtime or external media tool was exercised, and external-tool output varies by workflow, so it may carry private data this guidance does not cover.
