### PR TITLE
Build: retire unsupported x86 configurations

### DIFF
--- a/Source/FrameServer/FrameServer.vcxproj
+++ b/Source/FrameServer/FrameServer.vcxproj
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
@@ -22,6 +14,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{CED66FC7-8504-46D6-9957-78A099C02589}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>COMServer</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>FrameServer</ProjectName>
@@ -33,20 +26,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -61,13 +41,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -77,25 +51,11 @@
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\bin-x86\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>..\bin\</OutDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
-    <OutDir>..\bin-x86\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -116,48 +76,7 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level1</WarningLevel>
-      <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;COMSERVER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-      <AssemblyDebug>true</AssemblyDebug>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;COMSERVER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/Source/StaxRip.sln
+++ b/Source/StaxRip.sln
@@ -13,27 +13,17 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x64.ActiveCfg = Debug|x64
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x64.Build.0 = Debug|x64
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x86.ActiveCfg = Debug|x86
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x86.Build.0 = Debug|x86
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x64.ActiveCfg = Debug|x64
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x64.Build.0 = Debug|x64
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x86.ActiveCfg = Debug|x86
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x86.Build.0 = Debug|x86
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x64.ActiveCfg = Debug|x64
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x64.Build.0 = Debug|x64
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x86.ActiveCfg = Debug|Win32
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x86.Build.0 = Debug|Win32
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x64.ActiveCfg = Release|x64
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x64.Build.0 = Release|x64
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x86.ActiveCfg = Release|Win32
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/StaxRip.vbproj
+++ b/Source/StaxRip.vbproj
@@ -6,7 +6,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ApplicationIcon>Black.ico</ApplicationIcon>
     <AssemblyKeyContainerName>
     </AssemblyKeyContainerName>
@@ -86,27 +86,6 @@
     <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>bin-x86\</OutputPath>
-    <WarningLevel>1</WarningLevel>
-    <NoWarn>41998,42004,42025,42026,42029,42030,42031,42104,42105,42106,42107,42108,42109,42353,42354,42355</NoWarn>
-    <DebugType>Full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin-x86\</OutputPath>
-    <WarningLevel>1</WarningLevel>
-    <NoWarn>41998,42004,42025,42026,42029,42030,42031,42104,42105,42106,42107,42108,42109,42353,42354,42355</NoWarn>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DirectN, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Source/Tools/AutoCrop/AutoCrop.sln
+++ b/Source/Tools/AutoCrop/AutoCrop.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x64.ActiveCfg = Debug|x64
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x64.Build.0 = Debug|x64
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x86.ActiveCfg = Debug|x86
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x86.Build.0 = Debug|x86
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x64.ActiveCfg = Release|x64
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x64.Build.0 = Release|x64
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x86.ActiveCfg = Release|x86
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tools/AutoCrop/AutoCrop.vbproj
+++ b/Source/Tools/AutoCrop/AutoCrop.vbproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{1F25DC45-7E98-40EA-9047-6C837E558EE1}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <StartupObject>AutoCrop.Module1</StartupObject>
@@ -26,29 +26,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <OptionInfer>On</OptionInfer>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>..\..\bin-x86\Apps\Support\AutoCrop\</OutputPath>
-    <WarningLevel>0</WarningLevel>
-    <NoWarn>42105,42106,42107,42353,42354,42355</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <Optimize>true</Optimize>
-    <WarningLevel>0</WarningLevel>
-    <NoWarn>42105,42106,42107,42353,42354,42355</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Summary

- remove the x86 StaxRip and AutoCrop configurations and the matching Win32 FrameServer configurations
- keep the three projects coordinated so the managed executables and in-process native library cannot advertise mismatched architectures
- make omitted-platform direct project builds select x64

StaxRip supports x64 builds only. The checked-in build and release scripts already select x64, the updater selects x64 archives, and current release assets are x64-only.

## Preserved behavior

- both x64 solution mappings, including the existing StaxRip `Release|x64` to `Debug|x64` mapping
- all x64 project properties and output paths
- runtime architecture branches, package fields, build and release scripts, tracked AutoCrop artifacts, and `.gitignore`
- non-configuration text such as the C++ `Win32Proj` project keyword and old .NET bootstrapper display names

## Verification

- parsed all three edited project files as XML
- validated Debug and Release x64 configurations in both solutions
- confirmed both solutions reject `Debug|x86`
- confirmed omitted-platform property evaluation matches explicit x64 evaluation for StaxRip, FrameServer, and AutoCrop
- rebuilt StaxRip, FrameServer, and AutoCrop in Debug and Release x64
- required an exact five-file diff and checked it for whitespace errors

All six builds passed. The upstream FrameServer Release build retained its ten known conversion warnings; this configuration-only change introduced no new warning class.

## Follow-up integrated validation

Phase 1 was later combined with the dependent runtime cleanup and independently proposed native fixes in a portable x64 candidate:

- Debug and Release x64 solution builds passed with zero warnings and errors
- PE inspection identified the managed executable and native FrameServer DLL as x64
- the full GUI started, dismissed its owned changelog window, and opened four synthetic media fixtures
- ten AviSynth and VapourSynth cases passed
- 5,000 create/open/read/release cycles per engine passed with zero net handle growth
- a 3,928-file release-equivalent archive passed integrity and exact manifest checks

The six isolated x64 builds and configuration checks remain the direct evidence for this five-file Phase 1 patch. The portable results provide follow-up evidence for the stacked x64 candidate.

## Limits and impact

- the follow-up runtime and packaging results came from a stacked candidate, not this isolated branch
- no application runtime, ABI, packaging script, or release script changed in this patch
- x86 is unsupported and was intentionally not exercised
- an out-of-repository developer command that explicitly requests an obsolete configuration name will need to select x64
- `Source/BuildAndPack.ps1` and `Source/Release.ps1` were not invoked; their relevant copy, exclusion, and archive behavior was reproduced in an isolated scratch directory
- arbitrary user media, third-party plugins and scripts, hardware encoders, multi-hour jobs, live updates, release publication, and signing were not tested

Reverting the single commit restores the old configurations and defaults. Security, privacy, and logging behavior are unchanged.