### PR TITLE
FrameServer: keep VSScript loaded for process lifetime

### DIFF
--- a/Source/FrameServer/VapourSynthServer.cpp
+++ b/Source/FrameServer/VapourSynthServer.cpp
@@ -1,6 +1,48 @@
 
 #include "VapourSynthServer.h"
 
+#include <mutex>
+
+namespace
+{
+    using GetVSScriptAPI = const VSSCRIPTAPI* (__stdcall*)(int version);
+
+    struct VSScriptLibrary
+    {
+        GetVSScriptAPI getAPI = nullptr;
+        DWORD loadError = ERROR_SUCCESS;
+        bool libraryLoaded = false;
+    };
+
+    VSScriptLibrary LoadVSScriptLibrary()
+    {
+        static std::mutex mutex;
+        // Keep the embedded Python runtime loaded so later server instances can initialize.
+        static HMODULE module = nullptr;
+        static GetVSScriptAPI getAPI = nullptr;
+        std::lock_guard<std::mutex> lock(mutex);
+
+        if (module && getAPI)
+            return { getAPI, ERROR_SUCCESS, true };
+
+        HMODULE candidate = LoadLibrary(L"VSScript.dll");
+        if (!candidate)
+            return { nullptr, GetLastError(), false };
+
+        bool x64 = sizeof(void*) == 8;
+        auto candidateAPI = reinterpret_cast<GetVSScriptAPI>(GetProcAddress(candidate, x64 ? "getVSScriptAPI" : "_getVSScriptAPI@4"));
+        if (!candidateAPI)
+        {
+            FreeLibrary(candidate);
+            return { nullptr, ERROR_SUCCESS, true };
+        }
+
+        module = candidate;
+        getAPI = candidateAPI;
+        return { getAPI, ERROR_SUCCESS, true };
+    }
+}
+
 void logMessageHandler(int msgType, const char* msg, void* userData)
 {
     if (msgType > mtWarning) {
@@ -48,29 +90,18 @@ HRESULT __stdcall VapourSynthServer::OpenFile(WCHAR* file)
 {
     try
     {
-        static bool wasResolved = false;
+        VSScriptLibrary library = LoadVSScriptLibrary();
 
-        if (!wasResolved)
+        if (!library.libraryLoaded)
         {
-            m_vssDLL = LoadLibrary(L"VSScript.dll");
-
-            if (!m_vssDLL)
-            {
-                std::string msg = GetWinErrorMessage(GetLastError());
-                throw std::runtime_error("Failed to load VapourSynth:\r\n\r\n" + msg);
-            }
-
-            bool x64 = sizeof(void*) == 8;
-
-            vss_getVSScriptAPI = reinterpret_cast<decltype(vss_getVSScriptAPI)>(GetProcAddress(m_vssDLL, x64 ? "getVSScriptAPI" : "_getVSScriptAPI@4"));
-
-            if (!vss_getVSScriptAPI)
-                throw std::exception("Failed to load getVSScriptAPI function. Upgrade Vapoursynth to R55 or newer!");
+            std::string msg = GetWinErrorMessage(library.loadError);
+            throw std::runtime_error("Failed to load VapourSynth:\r\n\r\n" + msg);
         }
 
-        wasResolved = true;
+        if (!library.getAPI)
+            throw std::exception("Failed to load getVSScriptAPI function. Upgrade Vapoursynth to R55 or newer!");
 
-        m_vsScriptAPI = vss_getVSScriptAPI(VSSCRIPT_API_VERSION);
+        m_vsScriptAPI = library.getAPI(VSSCRIPT_API_VERSION);
 
         if (!m_vsScriptAPI)
             throw std::exception("Failed to initialize VapourSynth");
@@ -251,11 +282,6 @@ void VapourSynthServer::Free()
         m_vsScript = NULL;
     }
 
-    if (m_vssDLL)
-    {
-        FreeLibrary(m_vssDLL);
-        m_vssDLL = nullptr;
-    }
 }
 
 

--- a/Source/FrameServer/VapourSynthServer.h
+++ b/Source/FrameServer/VapourSynthServer.h
@@ -14,9 +14,6 @@
 #include <atomic>
 #include <array>
 
-const VSSCRIPTAPI* (__stdcall* vss_getVSScriptAPI) (int version);
-
-
 class VapourSynthServer : IFrameServer
 {
 
@@ -26,7 +23,6 @@ private:
     std::wstring        m_Error;
     ServerInfo          m_Info = {};
 
-    HMODULE             m_vssDLL = nullptr;
     const VSSCRIPTAPI*  m_vsScriptAPI = nullptr;
     const VSAPI*        m_vsAPI = nullptr;
     VSCore*             m_vsCore = nullptr;


### PR DESCRIPTION
## Summary

Keep one synchronized VSScript module and entry point for the process lifetime. Later `VapourSynthServer` instances reuse that valid entry point instead of unloading the module while process-wide runtime state remains active.

## Root cause

The previous code cached a process-wide resolved flag and function pointer, but each first server instance released the module handle during cleanup. A later server then called through an entry point from a module that was no longer loaded.

A first repair that loaded and released the module per instance passed the shipped R73 runtime, but the R79 compatibility fixture could not initialize a second embedded runtime after unload. Keeping one validated module for the process lifetime handles both versions. Loading and entry-point resolution are serialized, and a failed load or missing entry point remains retryable.

## Verification

- controlled lifecycle probe: unchanged build failed sequential, script-failure recovery, and overlapping-instance cases; this change passed all three
- missing-runtime preservation probe: a later open succeeded after the runtime became available in the same process
- isolated branch: FrameServer and the main solution rebuilt in Debug and Release x64
- exact v2.52.5 package fixture, SHA-256 `3ced91af31743d6e6611c700c265066bd85cb6954c251bd3dc218209299dcdd0`
  - AviSynth+ 3.7.5 and packaged VapourSynth R73: 10 native cases passed
  - packaged AutoCrop host: four normal and non-ASCII-path cases passed
- official VapourSynth R79 wheel with the packaged Python 3.13.9 runtime
  - five native cases passed
  - two packaged AutoCrop cases passed
- combined with draft pull requests #1987 and #1988
  - four x64 build gates passed with zero warnings
  - all R73, R79, AviSynth, and managed-host cases passed

The runtime cases covered normal script evaluation, representative first/middle/last frame reads, non-ASCII paths, invalid-script errors, sequential servers, and overlapping servers.

## Follow-up portable validation

This commit was later included in a broader portable x64 candidate with other independently proposed changes:

- the full GUI started, dismissed its owned changelog window, and opened four synthetic media fixtures
- ten AviSynth and VapourSynth bundled-filter and media cases passed
- after ten warm-up cycles per engine, 5,000 measured create/open/read/release cycles per engine passed with zero net handle growth and less than 64 MiB net private-memory growth
- a 3,928-file release-equivalent archive passed integrity and exact manifest checks

The isolated lifecycle and real-runtime matrices remain the direct evidence for this loader-lifetime repair. The portable results add representative application-level and packaging evidence.

## Impact and limits

The process now retains one VSScript module reference until process exit. The exported interface, API version, managed structure layout, frame ownership, error strings, and x64 output path are unchanged.

- the follow-up portable results came from an integrated candidate, not this isolated branch
- arbitrary user media, third-party plugins and scripts, hardware encoders, multi-hour jobs, cancellation, suspend/resume, and disk-full recovery were not tested
- `Source/BuildAndPack.ps1` and `Source/Release.ps1` were not invoked; their relevant copy, exclusion, and archive behavior was reproduced in an isolated scratch directory
- live update, release publication, and signing workflows were not exercised
- security, privacy, and logging behavior are unchanged

Reverting the single commit restores the prior loader lifetime.