### PR TITLE
Runtime: remove unsupported x86 branches

### DIFF
--- a/Source/Forms/MainForm.vb
+++ b/Source/Forms/MainForm.vb
@@ -1791,10 +1791,6 @@ Partial Public Class MainForm
 
             Text = $"{path.Base} - {g.DefaultCommands.GetApplicationDetails()}"
 
-            If Not Environment.Is64BitProcess Then
-                Text += " (32 bit)"
-            End If
-
             PreviewScript = Nothing
             SkipAssistant = True
 

--- a/Source/FrameServer/FrameServer.vcxproj
+++ b/Source/FrameServer/FrameServer.vcxproj
@@ -1,17 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
@@ -22,6 +14,7 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <ProjectGuid>{CED66FC7-8504-46D6-9957-78A099C02589}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
+    <Platform Condition="'$(Platform)' == ''">x64</Platform>
     <RootNamespace>COMServer</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectName>FrameServer</ProjectName>
@@ -33,20 +26,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v143</PlatformToolset>
-    <WholeProgramOptimization>false</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
@@ -61,13 +41,7 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -77,25 +51,11 @@
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
-    <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\bin-x86\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
     <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
     <LibraryPath>$(LibraryPath)</LibraryPath>
     <OutDir>..\bin\</OutDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <IncludePath>..\bin\Apps\FrameServer\VapourSynth\sdk\include\vapoursynth;$(IncludePath)</IncludePath>
-    <LibraryPath>$(LibraryPath)</LibraryPath>
-    <OutDir>..\bin-x86\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -116,48 +76,7 @@
       <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level1</WarningLevel>
-      <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;COMSERVER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-      <AssemblyDebug>true</AssemblyDebug>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;COMSERVER_EXPORTS;_WINDOWS;_USRDLL;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ConformanceMode>true</ConformanceMode>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <LanguageStandard>stdcpp17</LanguageStandard>
-    </ClCompile>
-    <Link>
-      <SubSystem>Windows</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>%(AdditionalDependencies)</AdditionalDependencies>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>

--- a/Source/General/GlobalClass.vb
+++ b/Source/General/GlobalClass.vb
@@ -859,7 +859,7 @@ Public Class GlobalClass
     End Function
 
     Function VerifyRequirements() As Boolean
-        If s.VerifyToolStatus AndAlso Environment.Is64BitProcess Then
+        If s.VerifyToolStatus Then
             SyncLock Package.ConfLock
                 For Each pack In Package.Items.Values
                     If Not pack.VerifyOK Then
@@ -2204,7 +2204,7 @@ Public Class GlobalClass
     End Sub
 
     Function IsDevelopmentPC() As Boolean
-        Return New DirectoryInfo(Application.StartupPath).Name.EndsWithEx("bin") OrElse New DirectoryInfo(Application.StartupPath).Name.EndsWithEx("bin-x86")
+        Return New DirectoryInfo(Application.StartupPath).Name.EndsWithEx("bin")
     End Function
 
     Sub RunTask(action As Action)

--- a/Source/General/Package.vb
+++ b/Source/General/Package.vb
@@ -12,6 +12,7 @@ Public Class Package
     Property Description As String
     Property DownloadURL As String
     Property Exclude As String()
+    <Obsolete("StaxRip supports x64 only. Use Filename instead.")>
     Property Filename32 As String
     Property Filter As String
     Property Find As Boolean = True
@@ -79,7 +80,6 @@ Public Class Package
     Shared Property Haali As Package = Add(New Package With {
         .Name = "Haali Splitter",
         .Filename = "splitter.x64.ax",
-        .Filename32 = "splitter.ax",
         .Description = "Haali Splitter is used by eac3to to write MKV files.",
         .Required = False,
         .IsIncluded = False,
@@ -203,7 +203,6 @@ Public Class Package
     Shared Property qaac As Package = Add(New Package With {
         .Name = "qaac",
         .Filename = "qaac64.exe",
-        .Filename32 = "qaac.exe",
         .Location = IO.Path.Combine("Audio", "qaac"),
         .WebURL = "https://github.com/nu774/qaac",
         .DownloadURL = "https://github.com/nu774/qaac/releases",
@@ -422,7 +421,6 @@ Public Class Package
         .Name = "AVSMeter",
         .Location = IO.Path.Combine("Support", "AVSMeter"),
         .Filename = "AVSMeter64.exe",
-        .Filename32 = "AVSMeter.exe",
         .Description = "Console app that displays AviSynth script clip info.",
         .HelpFilename = IO.Path.Combine("doc", "AVSMeter.html"),
         .WebURL = "https://forum.doom9.org/showthread.php?t=174797",
@@ -458,7 +456,6 @@ Public Class Package
     Shared Property MPC As Package = Add(New Package With {
         .Name = "MPC",
         .Filename = "mpc-be64.exe",
-        .Filename32 = "mpc-be.exe",
         .Filter = "|mpc-hc64.exe;mpc-be64.exe|All Files|*.*",
         .IsIncluded = False,
         .VersionAllowAny = True,
@@ -579,7 +576,6 @@ Public Class Package
     Shared Property avs2pipemod As Package = Add(New Package With {
         .Name = "avs2pipemod",
         .Filename = "avs2pipemod64.exe",
-        .Filename32 = "avs2pipemod.exe",
         .Location = IO.Path.Combine("Support", "avs2pipemod"),
         .WebURL = "https://github.com/chikuzen/avs2pipemod",
         .DownloadURL = "https://github.com/chikuzen/avs2pipemod/releases",
@@ -795,7 +791,6 @@ Public Class Package
     Shared Property NVEncC As Package = Add(New Package With {
         .Name = "NVEncC",
         .Filename = "NVEncC64.exe",
-        .Filename32 = "NVEncC.exe",
         .Location = IO.Path.Combine("Encoders", "NVEncC"),
         .HelpSwitch = "-h",
         .WebURL = "https://github.com/rigaya/NVEnc",
@@ -806,7 +801,6 @@ Public Class Package
     Shared Property QSVEncC As Package = Add(New Package With {
         .Name = "QSVEncC",
         .Filename = "QSVEncC64.exe",
-        .Filename32 = "QSVEncC.exe",
         .Location = IO.Path.Combine("Encoders", "QSVEncC"),
         .Description = "Intel hardware video encoder.",
         .WebURL = "https://github.com/rigaya/QSVEnc",
@@ -817,7 +811,6 @@ Public Class Package
     Shared Property VCEEncC As Package = Add(New Package With {
         .Name = "VCEEncC",
         .Filename = "VCEEncC64.exe",
-        .Filename32 = "VCEEncC.exe",
         .Location = IO.Path.Combine("Encoders", "VCEEncC"),
         .Description = "AMD hardware video encoder.",
         .HelpSwitch = "-h",
@@ -2774,7 +2767,7 @@ Public Class Package
 
     Property Filename As String
         Get
-            Return If(Not Environment.Is64BitProcess AndAlso Filename32 <> "", Filename32, FilenameValue)
+            Return FilenameValue
         End Get
         Set(value As String)
             FilenameValue = value

--- a/Source/General/ToolUpdate.vb
+++ b/Source/General/ToolUpdate.vb
@@ -205,7 +205,7 @@ Public Class ToolUpdate
 
         Dim x86 = {"_win32", "\x86", "-x86", "32-bit", "-win32"}
 
-        If Environment.Is64BitProcess AndAlso value.ToLowerInvariant.ContainsAny(x86) Then
+        If value.ToLowerInvariant.ContainsAny(x86) Then
             Return True
         End If
     End Function

--- a/Source/StaxRip.sln
+++ b/Source/StaxRip.sln
@@ -13,27 +13,17 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x64.ActiveCfg = Debug|x64
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x64.Build.0 = Debug|x64
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x86.ActiveCfg = Debug|x86
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Debug|x86.Build.0 = Debug|x86
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x64.ActiveCfg = Debug|x64
 		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x64.Build.0 = Debug|x64
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x86.ActiveCfg = Debug|x86
-		{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}.Release|x86.Build.0 = Debug|x86
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x64.ActiveCfg = Debug|x64
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x64.Build.0 = Debug|x64
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x86.ActiveCfg = Debug|Win32
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Debug|x86.Build.0 = Debug|Win32
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x64.ActiveCfg = Release|x64
 		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x64.Build.0 = Release|x64
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x86.ActiveCfg = Release|Win32
-		{CED66FC7-8504-46D6-9957-78A099C02589}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/StaxRip.vbproj
+++ b/Source/StaxRip.vbproj
@@ -6,7 +6,7 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{8DB07BD5-D3DD-49CB-85ED-AB35EAF3C951}</ProjectGuid>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ApplicationIcon>Black.ico</ApplicationIcon>
     <AssemblyKeyContainerName>
     </AssemblyKeyContainerName>
@@ -86,27 +86,6 @@
     <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>bin-x86\</OutputPath>
-    <WarningLevel>1</WarningLevel>
-    <NoWarn>41998,42004,42025,42026,42029,42030,42031,42104,42105,42106,42107,42108,42109,42353,42354,42355</NoWarn>
-    <DebugType>Full</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin-x86\</OutputPath>
-    <WarningLevel>1</WarningLevel>
-    <NoWarn>41998,42004,42025,42026,42029,42030,42031,42104,42105,42106,42107,42108,42109,42353,42354,42355</NoWarn>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42024,42032,42036,42099</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="DirectN, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/Source/Tools/AutoCrop/AutoCrop.sln
+++ b/Source/Tools/AutoCrop/AutoCrop.sln
@@ -8,19 +8,13 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x64.ActiveCfg = Debug|x64
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x64.Build.0 = Debug|x64
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x86.ActiveCfg = Debug|x86
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Debug|x86.Build.0 = Debug|x86
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x64.ActiveCfg = Release|x64
 		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x64.Build.0 = Release|x64
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x86.ActiveCfg = Release|x86
-		{1F25DC45-7E98-40EA-9047-6C837E558EE1}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/Tools/AutoCrop/AutoCrop.vbproj
+++ b/Source/Tools/AutoCrop/AutoCrop.vbproj
@@ -3,7 +3,7 @@
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <ProjectGuid>{1F25DC45-7E98-40EA-9047-6C837E558EE1}</ProjectGuid>
     <OutputType>Exe</OutputType>
     <StartupObject>AutoCrop.Module1</StartupObject>
@@ -26,29 +26,6 @@
   </PropertyGroup>
   <PropertyGroup>
     <OptionInfer>On</OptionInfer>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <DefineDebug>true</DefineDebug>
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>..\..\bin-x86\Apps\Support\AutoCrop\</OutputPath>
-    <WarningLevel>0</WarningLevel>
-    <NoWarn>42105,42106,42107,42353,42354,42355</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DefineTrace>true</DefineTrace>
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <Optimize>true</Optimize>
-    <WarningLevel>0</WarningLevel>
-    <NoWarn>42105,42106,42107,42353,42354,42355</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <WarningsAsErrors>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036</WarningsAsErrors>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
## Dependency

This is a stacked draft that depends on #1992. Until #1992 merges, GitHub shows both
Phase 1 and Phase 2 in this PR. The Phase 2 review unit is commit `ed32aae0` and changes
four managed source files.

## What changed

- remove the unreachable 32-bit suffix from the main-window title
- make the runtime requirement check consistently x64-only
- stop treating the retired `bin-x86` output as a development folder
- stop selecting internal package filenames by process bitness
- always exclude x86 assets from tool-update selection
- remove eight unused `Filename32` catalog initializers

The public `Package.Filename32` property is retained and marked obsolete. Its storage
and accessors still work, so this phase does not force a breaking public API removal.

## Why

StaxRip documents and ships x64 only, its build/release scripts request x64, and the
current update path recognizes x64 release archives. After #1992 removes the obsolete
project configurations, these runtime branches become unreachable and can otherwise
mislead future maintenance.

Phase 2 must follow Phase 1: landing the runtime changes while x86 configurations still
build would make those configurations select x64 package/runtime behavior.

## User and developer impact

Supported x64 behavior is unchanged. Internal package and update selection now states
the supported architecture directly. External code using `Filename32` receives an
obsolete warning and can migrate to `Filename`, while existing access remains valid.

## Validation

Phase 2 branch:

- Debug x64 solution rebuild: pass, zero warnings/errors
- Release x64 solution rebuild: pass; only the ten pre-existing FrameServer conversion
  warnings remain on this isolated branch
- IL inspection: `Filename32` accessors remain and `Filename` has no process-bitness
  branch
- focused managed probe: legacy storage works, the obsolete attribute is present, and
  x86 tool assets are rejected

Stacked integration candidate (Phase 1 + Phase 2 + the existing native PR branches):

- Debug and Release x64 solution rebuilds: pass, zero warnings/errors
- portable v2.52.5 startup and changelog dismissal: pass
- four representative GUI source workflows: pass
- ten AviSynth/VapourSynth media and bundled-plugin scripts: pass
- 5,000 open/read/release cycles per engine: pass with zero handle growth
- scratch release-equivalent copy/archive/integrity/manifest closure: pass; no release
  was published and the hard-coded release scripts were not invoked

