### PR TITLE
Support: add structured bug report preview

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug_report.yml
@@ -4,8 +4,8 @@ body:
   - type: textarea
     id: whathappened
     attributes:
-      label: Describe the bug
-      description: A clear and concise description of what the bug is.
+      label: Observed behavior
+      description: Describe what happened, including the first affected timestamp or processing stage when relevant.
     validations:
       required: true
   - type: textarea
@@ -20,6 +20,24 @@ body:
     attributes:
       label: Expected behavior
       description: A clear and concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Affected area
+      options:
+        - Source opening or demuxing
+        - Audio processing or encoding
+        - Video processing or encoding
+        - AviSynth+
+        - VapourSynth
+        - Muxing or output
+        - GUI, jobs, projects, or settings
+        - Included tools or updates
+        - Other or unknown
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
@@ -32,24 +50,74 @@ body:
     id: os
     attributes:
       label: OS
-      multiple: true
+      multiple: false
       options:
         - Windows 11
         - Windows 10
         - Windows 8(.1)
         - Windows 7
+        - Windows Server or other/unknown
+    validations:
+      required: true
   - type: dropdown
     id: frameserver
     attributes:
       label: Frame Server
-      multiple: true
+      description: Select the path that was active when the problem occurred.
+      multiple: false
       options:
         - AviSynth+
         - VapourSynth
+        - Both (tested separately)
+        - Not used or audio-only
+        - Unknown
+    validations:
+      required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Reproduction frequency
+      options:
+        - Every time
+        - Intermittent
+        - Once
+        - Unable to reproduce again
+    validations:
+      required: true
+  - type: input
+    id: lastworking
+    attributes:
+      label: Last known working StaxRip version
+      description: Leave blank if the problem has always occurred or you do not know.
+      placeholder: e.g. 2.52.3 or unknown
+  - type: dropdown
+    id: cleantemplate
+    attributes:
+      label: Reproduces with a clean built-in template
+      description: Test this only when doing so will not risk the source or an existing output.
+      options:
+        - "Yes"
+        - "No"
+        - Not tested
+    validations:
+      required: true
+  - type: textarea
+    id: supportreport
+    attributes:
+      label: StaxRip support report
+      description: In StaxRip, open Help > Support Report Preview, review the report, and paste it here. Leave blank if your version does not provide this command.
   - type: textarea
     id: moreinfo
     attributes:
       label: Additional information
       description: |
-        Add any other context about the problem here.
-        If applicable, add screenshots to help explain your problem and/or provide a log file. The log file is located in the temp folder and the temp folder is located in the same directory as the source file. The log file ends with _staxrip.log.
+        Add screenshots or a minimal redistributable sample when they are necessary to reproduce the problem.
+        If your StaxRip version does not provide a support report and a maintainer needs the job log, open Project > Log File, right-click the log, and select Save Obfuscated As.
+        Review every saved file before attaching it. Obfuscation can leave unrelated paths, scripts, command lines, media details, tool output, and system information.
+  - type: checkboxes
+    id: privacyreview
+    attributes:
+      label: Privacy review
+      options:
+        - label: I reviewed the issue text and every attachment for private paths, names, media details, scripts, credentials, and other sensitive content.
+          required: true

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -47,7 +47,7 @@
     - [Jobs](Usage/User-Interface/Jobs.md) :x:
     - [Menu Editor](Usage/User-Interface/Menu-Editor.md) :x:
     - [Events](Usage/User-Interface/Events.md) :x:
-    - [Log File Viewer](Usage/User-Interface/Log-File-Viewer.md) :x:
+    - [Log File Viewer](Usage/User-Interface/Log-File-Viewer.md)
     - [Apps Manager](Usage/User-Interface/Apps-Manager.md) :x:
     - [Project Options](Usage/User-Interface/Project-Options.md) :x:
     - [Settings](Usage/User-Interface/Settings.md) :x:
@@ -105,6 +105,7 @@
     - [Audio Encoders](Tools/Supported-Encoders/Audio.md) :x:
 
 ## [Support](Support/README.md)
+- [Bug Reports](Support/Bug-Reports.md)
 
 ## [Contribution](Contribution/README.md) :x:
 

--- a/Docs/Support/Bug-Reports.md
+++ b/Docs/Support/Bug-Reports.md
@@ -1,0 +1,63 @@
+# [Documentation](../README.md) / [Support](README.md) / Bug Reports
+
+A useful bug report identifies the failing stage and gives another person enough information to distinguish a StaxRip problem from a source, setting, plugin, or external-tool problem.
+
+## Before opening an issue
+
+1. Reproduce the problem with the latest release when practical.
+2. Search the issue tracker and changelog for the same symptom.
+3. Try a clean built-in template when that will not risk your source or output.
+4. Record whether the problem affects one source or several sources.
+5. Keep the smallest sample that still reproduces the problem, but share it only when you have permission.
+
+## Create the support report
+
+Open `Help > Support Report Preview...`. The report captures the current project and selected stream, so create it while the affected project is loaded. Complete the reporter prompts, review the text, and select `Copy Report`.
+
+The command option is off by default. Enable it only when the generated arguments help explain the failure. Sanitized commands are still a best-effort export and require manual review.
+
+Older StaxRip releases may not provide the support report. If a maintainer requests a log, use `Project > Log File > Save Obfuscated As...` and review the saved file before attaching it. Do not attach the raw log by default.
+
+## Details StaxRip cannot supply
+
+Add these facts yourself:
+
+- what you saw or heard, not only that the output was "wrong";
+- what you expected;
+- whether the failure is repeatable and how often it occurs;
+- the first failing and last known working StaxRip versions;
+- whether a clean template and a different source reproduce it;
+- the first affected timestamp or processing stage;
+- whether a manual command used the same executable version and input method.
+
+## Details by problem type
+
+### Audio corruption or synchronization
+
+Describe whether the result contains noise, silence, clicks, missing channels, drift, a constant offset, or a duration mismatch. State the first affected timestamp. Compare the input, intermediate, and final files when the workflow creates them.
+
+If a manual FFmpeg command works, state whether it used the same FFmpeg executable, stream mapping, input file or pipe, decoder, sample format, channel layout, and output options. A command that looks similar but uses a different executable or input method is not an exact comparison.
+
+### Encoder or external-tool failure
+
+Include the failing stage, decimal and hexadecimal exit code, tool version, and whether the same source fails every time. If the tool crashes, state whether other sources and a simpler profile also crash.
+
+### AviSynth+ or VapourSynth
+
+Select the frame server that was active. Include the relevant runtime and plugin versions. State whether previewing the script fails before encoding begins. Do not paste a script until you have removed paths, media names, comments, credentials, and custom code you do not want to publish.
+
+### GUI, jobs, projects, or settings
+
+List the exact controls used and the order of actions. State whether restarting StaxRip or using a clean settings directory changes the result. Attach a screenshot only after checking window titles, paths, job names, and media names.
+
+### Updates and included tools
+
+Identify the component, previous version, new version, and observed failure. State whether restoring the previous component changes the result. Do not publish download URLs that contain credentials or signed query parameters.
+
+## Samples and attachments
+
+Use synthetic or freely redistributable media when possible. A small sample is better than a complete source. Check samples for private audio, subtitles, chapters, cover art, titles, tags, and location or device metadata.
+
+GitHub issues are public. Remove personal paths, names, network locations, credentials, private media details, and copyrighted material you cannot redistribute.
+
+[Log File Viewer and report details](../Usage/User-Interface/Log-File-Viewer.md)

--- a/Docs/Support/README.md
+++ b/Docs/Support/README.md
@@ -1,5 +1,9 @@
 ﻿# [Documentation](../README.md) / Support
 
+## Bug reports
+
+See [Bug Reports](Bug-Reports.md) for the information that helps reproduce a problem and for privacy guidance on reports, logs, screenshots, and samples.
+
 #### If you want to keep StaxRip alive, support its development, get early access to new releases or just say *thanks*, please consider visiting:
 [![Static Badge](https://img.shields.io/badge/Patreon-F16061?style=for-the-badge&logo=Patreon&labelColor=hsl(156%2C%2080%25%2C%2020%25)&color=hsl(156%2C%2080%25%2C%2020%25))](https://www.patreon.com/Dendraspis)  [![Static Badge](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=Ko-Fi&labelColor=hsl(156%2C%2080%25%2C%2020%25)&color=hsl(156%2C%2080%25%2C%2020%25))](https://ko-fi.com/Dendraspis)  [![Static Badge](https://img.shields.io/badge/BuyMeACoffee-BuyMeACoffee?style=for-the-badge&logo=BuyMeACoffee&labelColor=hsl(156%2C%2080%25%2C%2020%25)&color=hsl(156%2C%2080%25%2C%2020%25))](https://www.buymeacoffee.com/Dendraspis)
 

--- a/Docs/Usage/User-Interface/Log-File-Viewer.md
+++ b/Docs/Usage/User-Interface/Log-File-Viewer.md
@@ -1,0 +1,62 @@
+# [Documentation](../../README.md) / [Usage](../README.md) / [User Interface](README.md) / Log File Viewer
+
+The Log File Viewer shows the current job log. Open it with `Project > Log File` or press `F8`.
+
+Job logs are useful for troubleshooting, but they can contain file paths, file names, media metadata, scripts, command lines, tool output, and system details. Do not post a raw log without reviewing it.
+
+## Support report preview
+
+Open `Help > Support Report Preview...` to create an editable Markdown report for a GitHub issue or support discussion. You can also open the Log File Viewer, right-click the log, and select `Preview Support Report...`.
+
+The report is generated locally from a fixed allowlist. StaxRip does not upload it. The report includes:
+
+- the StaxRip, settings, Windows, and process-architecture versions;
+- the configured frame server, encoder, muxer, cutting, and audio path;
+- technical video and selected audio-stream properties;
+- versions of core and configured encoders, plus versioned tools named in the current log;
+- numeric failing exit codes found in the current log;
+- prompts for the observations that StaxRip cannot determine automatically.
+
+The default report does not include:
+
+- paths, file names, source names, or target names;
+- media titles, stream titles, template names, or profile names;
+- scripts, custom switches, event commands, or other free-form text;
+- raw tool output, exception text, or the complete job log;
+- user names, machine names, URLs, credentials, or file hashes.
+
+Technical properties such as codec, dimensions, duration, and stream layout can still describe the source. Review the preview and remove anything you do not want to publish.
+
+### Command summaries
+
+The command option is off by default. Enable `Include sanitized command summaries` before editing the report when a maintainer needs the generated encoder arguments.
+
+StaxRip omits standard paths and replaces detected custom or text-valued arguments. It also removes Windows paths, URLs, email addresses, and common credential arguments. This is a best-effort safeguard because command syntax is extensible. Review every command before sharing it.
+
+Muxer commands are not included because muxer profiles can contain complete free-form command templates.
+
+## Copying a report
+
+1. Reproduce the problem or load the affected project.
+2. Open `Help > Support Report Preview...`.
+3. Decide whether sanitized commands are necessary.
+4. Complete the `Reporter notes` section in the preview.
+5. Remove any technical detail you do not want to publish.
+6. Select `Copy Report` and paste the result into the issue form.
+
+For intermittent problems, state how often the failure occurs. For media corruption, describe the symptom, the first affected timestamp, and how you checked the output. If a manual command works, say whether it used the same executable version and input method as StaxRip.
+
+## Other Log File Viewer actions
+
+Right-click the log to access these actions:
+
+- `Save As...` saves the raw displayed log.
+- `Save Obfuscated As...` replaces the current source path and source name before saving.
+- `Preview Support Report...` creates the structured report described above.
+- `Open in Text Editor` opens the current raw log in the configured editor.
+- `Show in File Explorer` selects the current raw log.
+- `Show History` opens the saved log folder.
+
+`Save Obfuscated As...` is not a complete privacy filter. Unrelated target paths, scripts, command lines, tool output, and system details can remain. Use the support report preview for a public issue. Attach an obfuscated log only when a maintainer needs it and only after reviewing the saved file.
+
+[Back to User Interface](README.md)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Any contribution is highly appreciated!
 - You can also have a look at the [Changelog](https://github.com/staxrip/staxrip/blob/master/CHANGELOG.md) to see if there is an entry already made for the bug/feature request you are experiencing/desiring.
     - Supporters please use the [Changelog for Supporters](https://github.com/staxrip/staxrip/blob/master/CHANGELOG-SUPPORTER.md) instead.
 - If the [Latest Release](https://github.com/staxrip/staxrip/releases/latest) does not solve your problem, please use the [Issue Tracker](https://github.com/staxrip/staxrip/issues). You need to be as precise as possible using the Issue Tracker template when opening a thread in it.
+- Before opening an issue, use `Help > Support Report Preview...` when that command is available. Review the report before pasting it. See the [Log File Viewer documentation](Docs/Usage/User-Interface/Log-File-Viewer.md) for its contents and privacy limits.
 
 ### Community
 - Feel free to join in the [StaxRip Community on Discord](https://discord.gg/uz8pVR79Bd) , where you can chat and share knowledge with us and other StaxRip users. 

--- a/Source/Forms/LogForm.vb
+++ b/Source/Forms/LogForm.vb
@@ -51,6 +51,7 @@ Public Class LogForm
                                                  End If
                                              End Using
                                          End Sub, Keys.Control Or Keys.Alt Or Keys.S).SetImage(Symbol.Save)
+        cms.Add("Preview Support Report...", Sub() g.DefaultCommands.ShowSupportReport(), Keys.Control Or Keys.Shift Or Keys.C).SetImage(Symbol.Copy)
         cms.Add("Open in Text Editor", Sub() g.ShellExecute(g.GetTextEditorPath, p.Log.GetPath.Escape), Keys.Control Or Keys.T).SetImage(Symbol.Edit)
         cms.Add("Show in File Explorer", Sub() g.SelectFileWithExplorer(p.Log.GetPath), Keys.Control Or Keys.E).SetImage(Symbol.FileExplorer)
         cms.Add("Show History", Sub() g.ShellExecute(Path.Combine(Folder.Settings, "Log Files")), Keys.Control Or Keys.H).SetImage(Symbol.ClockLegacy)

--- a/Source/Forms/MainForm.vb
+++ b/Source/Forms/MainForm.vb
@@ -4537,6 +4537,7 @@ Partial Public Class MainForm
         ret.Add("Help|Changelog", NameOf(g.DefaultCommands.ExecuteCommandLine), Symbol.Bookmarks, {"https://github.com/staxrip/staxrip/blob/master/CHANGELOG.md"})
         ret.Add("Help|Support", NameOf(g.DefaultCommands.ExecuteCommandLine), Symbol.Heart, {"https://github.com/staxrip/staxrip?tab=readme-ov-file#contribution--support"})
         ret.Add("Help|-")
+        ret.Add("Help|Support Report Preview...", NameOf(g.DefaultCommands.ShowSupportReport), Symbol.Copy)
         ret.Add("Help|Report an issue", NameOf(g.DefaultCommands.ExecuteCommandLine), Symbol.fa_bug, {"https://github.com/staxrip/staxrip/issues/new/choose"})
         ret.Add("Help|-")
         ret.Add("Help|Discord Server", NameOf(g.DefaultCommands.ExecuteCommandLine), Symbol.People, {"https://discord.gg/uz8pVR79Bd"})

--- a/Source/Forms/SupportReportForm.vb
+++ b/Source/Forms/SupportReportForm.vb
@@ -1,0 +1,121 @@
+Imports StaxRip.UI
+
+Public Class SupportReportForm
+    Inherits FormBase
+
+    Private ReadOnly IncludeCommandsCheckBox As New CheckBox()
+    Private ReadOnly NoticeLabel As New Label()
+    Private ReadOnly ReportTextBox As New RichTextBoxEx()
+    Private ReadOnly CopyButton As New ButtonEx()
+    Private ReadOnly CloseButton As New ButtonEx()
+    Private ReadOnly LayoutPanel As New TableLayoutPanel()
+    Private ReadOnly ButtonPanel As New FlowLayoutPanel()
+
+    Sub New()
+        Text = $"Support Report Preview - {g.DefaultCommands.GetApplicationDetails()}"
+        ShowIcon = False
+        StartPosition = FormStartPosition.CenterParent
+        KeyPreview = True
+        RestoreClientSize(58, 42)
+
+        NoticeLabel.AutoSize = True
+        NoticeLabel.Dock = DockStyle.Fill
+        NoticeLabel.Margin = New Padding(12, 10, 12, 4)
+        NoticeLabel.Text = "Choose the command option before editing. Review the report before sharing it. Raw logs, paths, names, titles, scripts, and custom text are excluded by default."
+
+        IncludeCommandsCheckBox.AutoSize = True
+        IncludeCommandsCheckBox.Margin = New Padding(12, 4, 12, 8)
+        IncludeCommandsCheckBox.Text = "Include sanitized command summaries (manual review required)"
+
+        ReportTextBox.AcceptsTab = True
+        ReportTextBox.DetectUrls = False
+        ReportTextBox.Dock = DockStyle.Fill
+        ReportTextBox.Font = FontManager.GetCodeFont()
+        ReportTextBox.Margin = New Padding(12, 0, 12, 8)
+        ReportTextBox.WordWrap = False
+
+        CopyButton.AutoSize = True
+        CopyButton.Text = "Copy Report"
+        CloseButton.AutoSize = True
+        CloseButton.DialogResult = DialogResult.Cancel
+        CloseButton.Text = "Close"
+
+        ButtonPanel.AutoSize = True
+        ButtonPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink
+        ButtonPanel.Dock = DockStyle.Fill
+        ButtonPanel.FlowDirection = FlowDirection.RightToLeft
+        ButtonPanel.Margin = New Padding(12, 0, 12, 10)
+        ButtonPanel.Controls.Add(CloseButton)
+        ButtonPanel.Controls.Add(CopyButton)
+
+        LayoutPanel.ColumnCount = 1
+        LayoutPanel.ColumnStyles.Add(New ColumnStyle(SizeType.Percent, 100.0F))
+        LayoutPanel.Dock = DockStyle.Fill
+        LayoutPanel.RowCount = 4
+        LayoutPanel.RowStyles.Add(New RowStyle(SizeType.AutoSize))
+        LayoutPanel.RowStyles.Add(New RowStyle(SizeType.AutoSize))
+        LayoutPanel.RowStyles.Add(New RowStyle(SizeType.Percent, 100.0F))
+        LayoutPanel.RowStyles.Add(New RowStyle(SizeType.AutoSize))
+        LayoutPanel.Controls.Add(NoticeLabel, 0, 0)
+        LayoutPanel.Controls.Add(IncludeCommandsCheckBox, 0, 1)
+        LayoutPanel.Controls.Add(ReportTextBox, 0, 2)
+        LayoutPanel.Controls.Add(ButtonPanel, 0, 3)
+        Controls.Add(LayoutPanel)
+
+        AcceptButton = CopyButton
+        CancelButton = CloseButton
+
+        AddHandler IncludeCommandsCheckBox.CheckedChanged, AddressOf RefreshReport
+        AddHandler CopyButton.Click, AddressOf CopyReport
+        AddHandler ReportTextBox.TextChanged, AddressOf ReportChanged
+        AddHandler ThemeManager.CurrentThemeChanged, AddressOf OnThemeChanged
+
+        RefreshReport()
+        ApplyTheme()
+    End Sub
+
+    Protected Overrides Sub Dispose(disposing As Boolean)
+        RemoveHandler ThemeManager.CurrentThemeChanged, AddressOf OnThemeChanged
+        MyBase.Dispose(disposing)
+    End Sub
+
+    Private Sub RefreshReport()
+        ReportTextBox.Text = SupportReportBuilder.Build(p, New SupportReportOptions With {
+            .IncludeSanitizedCommands = IncludeCommandsCheckBox.Checked
+        })
+        ReportTextBox.SelectionStart = 0
+        ReportTextBox.SelectionLength = 0
+    End Sub
+
+    Private Sub RefreshReport(sender As Object, args As EventArgs)
+        RefreshReport()
+    End Sub
+
+    Private Sub CopyReport(sender As Object, args As EventArgs)
+        ReportTextBox.Text.ToClipboard()
+        CopyButton.Text = "Copied"
+    End Sub
+
+    Private Sub ReportChanged(sender As Object, args As EventArgs)
+        CopyButton.Text = "Copy Report"
+    End Sub
+
+    Private Sub OnThemeChanged(theme As Theme)
+        ApplyTheme(theme)
+    End Sub
+
+    Private Sub ApplyTheme()
+        ApplyTheme(ThemeManager.CurrentTheme)
+    End Sub
+
+    Private Sub ApplyTheme(theme As Theme)
+        If DesignHelp.IsDesignMode Then Return
+
+        BackColor = theme.General.BackColor
+        ForeColor = theme.General.ForeColor
+        LayoutPanel.BackColor = theme.General.BackColor
+        ButtonPanel.BackColor = theme.General.BackColor
+        NoticeLabel.ForeColor = theme.General.ForeColor
+        IncludeCommandsCheckBox.ForeColor = theme.General.ForeColor
+    End Sub
+End Class

--- a/Source/General/GlobalCommands.vb
+++ b/Source/General/GlobalCommands.vb
@@ -28,6 +28,13 @@ Public Class GlobalCommands
         End If
     End Sub
 
+    <Command("Builds an editable support report from an allowlist of current project details.")>
+    Sub ShowSupportReport()
+        Using form As New SupportReportForm()
+            form.ShowDialog()
+        End Using
+    End Sub
+
     <Command("Allows to use StaxRip's demuxing GUIs independently.")>
     Sub ShowDemuxTool()
         Using form As New SimpleSettingsForm("Demux")

--- a/Source/General/SupportReportBuilder.vb
+++ b/Source/General/SupportReportBuilder.vb
@@ -1,0 +1,490 @@
+Imports System.Globalization
+Imports System.Text
+Imports System.Text.RegularExpressions
+
+Imports StaxRip.VideoEncoderCommandLine
+
+Public NotInheritable Class SupportReportOptions
+    Property IncludeSanitizedCommands As Boolean
+End Class
+
+' Keep this report allowlist-based. Do not append raw logs, paths, media titles, scripts, profile names,
+' or arbitrary user-entered values. A new field needs a privacy review before it is added here.
+Public NotInheritable Class SupportReportBuilder
+    Const ReportSchemaVersion = 1
+
+    Private Sub New()
+    End Sub
+
+    Shared Function Build(proj As Project, options As SupportReportOptions) As String
+        If proj Is Nothing Then Throw New ArgumentNullException(NameOf(proj))
+        If options Is Nothing Then options = New SupportReportOptions()
+
+        Dim sb As New StringBuilder()
+
+        sb.AppendLine("## StaxRip support report")
+        sb.AppendLine()
+        sb.AppendLine("> Generated from an allowlist of diagnostic fields. Review and edit this report before sharing it.")
+        sb.AppendLine("> File names, paths, media titles, template names, scripts, custom text, and the raw log are not included.")
+        sb.AppendLine()
+
+        AppendApplication(sb)
+        AppendWorkflow(sb, proj)
+        AppendSourceVideo(sb, proj)
+        AppendAudio(sb, proj)
+        AppendTools(sb, proj)
+        AppendFailureSummary(sb, proj)
+        AppendCommands(sb, proj, options.IncludeSanitizedCommands)
+        AppendReporterPrompts(sb)
+        AppendPrivacySummary(sb, options.IncludeSanitizedCommands)
+
+        Return sb.ToString().TrimEnd() + Environment.NewLine
+    End Function
+
+    Private Shared Sub AppendApplication(sb As StringBuilder)
+        AppendHeading(sb, "Application")
+        AppendItem(sb, "Report schema", ReportSchemaVersion.ToString(CultureInfo.InvariantCulture))
+        AppendItem(sb, "StaxRip", g.DefaultCommands.GetApplicationDetails())
+
+        If s?.Version IsNot Nothing Then
+            AppendItem(sb, "Settings version", FormatVersion(s.Version))
+        End If
+
+        AppendItem(sb, "Windows", OSVersion.VersionString)
+        AppendItem(sb, "Process architecture", If(Environment.Is64BitProcess, "x64", "x86"))
+        AppendItem(sb, "UI culture", CultureInfo.CurrentCulture.Name)
+    End Sub
+
+    Private Shared Sub AppendWorkflow(sb As StringBuilder, proj As Project)
+        AppendHeading(sb, "Configured workflow")
+        AppendItem(sb, "Template", If(String.IsNullOrWhiteSpace(proj.TemplateName), "Not named", "Configured (name omitted)"))
+        AppendItem(sb, "Video encoding", If(proj.SkipVideoEncoding, "Skipped", "Enabled"))
+        AppendItem(sb, "Audio encoding", If(proj.SkipAudioEncoding, "Skipped", "Enabled"))
+        AppendItem(sb, "Audio source", If(proj.UseScriptAsAudioSource, "Frame-server script", "Selected audio stream or file"))
+        AppendItem(sb, "Frame server", GetFrameServer(proj))
+        AppendItem(sb, "Video encoder", GetTypeName(proj.VideoEncoder))
+
+        If proj.VideoEncoder?.Muxer IsNot Nothing Then
+            AppendItem(sb, "Muxer", GetTypeName(proj.VideoEncoder.Muxer))
+        End If
+
+        AppendItem(sb, "Target container", GetFileType(proj.TargetFile))
+
+        If proj.Ranges IsNot Nothing AndAlso proj.Ranges.Count > 0 Then
+            AppendItem(sb, "Cutting", $"{proj.CuttingMode}; {proj.Ranges.Count} range(s)")
+        Else
+            AppendItem(sb, "Cutting", "Not configured")
+        End If
+
+        If proj.Script IsNot Nothing Then
+            Dim activeFilters = If(proj.Script.Filters Is Nothing, 0, proj.Script.Filters.Where(Function(filter) filter.Active).Count())
+            AppendItem(sb, "Active video filters", activeFilters.ToString(CultureInfo.InvariantCulture))
+        End If
+
+        AppendItem(sb, "Project custom script text", PresentOrAbsent(Not String.IsNullOrWhiteSpace(proj.CodeAtTop) OrElse Not String.IsNullOrWhiteSpace(proj.CodeAtBottom)) + " (content omitted)")
+    End Sub
+
+    Private Shared Sub AppendSourceVideo(sb As StringBuilder, proj As Project)
+        AppendHeading(sb, "Source video")
+
+        If String.IsNullOrWhiteSpace(proj.SourceFile) Then
+            sb.AppendLine("No source is loaded.")
+            sb.AppendLine()
+            Return
+        End If
+
+        AppendItem(sb, "Source files", If(proj.SourceFiles?.Count > 0, proj.SourceFiles.Count, 1).ToString(CultureInfo.InvariantCulture))
+        AppendItem(sb, "Container", GetFileType(proj.SourceFile))
+        AppendOptionalItem(sb, "Format", proj.SourceVideoFormat)
+        AppendOptionalItem(sb, "Format profile", proj.SourceVideoFormatProfile)
+        AppendOptionalItem(sb, "HDR format", proj.SourceVideoHdrFormat)
+
+        If proj.SourceWidth > 0 AndAlso proj.SourceHeight > 0 Then
+            AppendItem(sb, "Dimensions", $"{proj.SourceWidth} x {proj.SourceHeight}")
+        End If
+
+        If proj.SourceFrameRate > 0 Then
+            AppendItem(sb, "Frame rate", proj.SourceFrameRate.ToString(CultureInfo.InvariantCulture) + OptionalSuffix(proj.SourceFrameRateMode))
+        End If
+
+        If proj.SourceFrames > 0 Then AppendItem(sb, "Frames", proj.SourceFrames.ToString(CultureInfo.InvariantCulture))
+        If proj.SourceSeconds > 0 Then AppendItem(sb, "Duration", TimeSpan.FromSeconds(proj.SourceSeconds).ToString("c", CultureInfo.InvariantCulture))
+        If proj.SourceBitrate > 0 Then AppendItem(sb, "Bitrate", proj.SourceBitrate.ToString(CultureInfo.InvariantCulture) + " kb/s")
+        If proj.SourceVideoBitDepth > 0 Then AppendItem(sb, "Bit depth", proj.SourceVideoBitDepth.ToString(CultureInfo.InvariantCulture))
+
+        AppendOptionalItem(sb, "Chroma subsampling", proj.SourceChromaSubsampling)
+        AppendOptionalItem(sb, "Color space", proj.SourceColorSpace)
+        AppendOptionalItem(sb, "Scan type", proj.SourceScanType)
+        AppendOptionalItem(sb, "Scan order", proj.SourceScanOrder)
+
+        If proj.TargetWidth > 0 AndAlso proj.TargetHeight > 0 Then
+            AppendItem(sb, "Configured output dimensions", $"{proj.TargetWidth} x {proj.TargetHeight}")
+        End If
+
+        If proj.TargetFrameRate > 0 Then
+            AppendItem(sb, "Configured output frame rate", proj.TargetFrameRate.ToString(CultureInfo.InvariantCulture))
+        End If
+    End Sub
+
+    Private Shared Sub AppendAudio(sb As StringBuilder, proj As Project)
+        AppendHeading(sb, "Audio")
+
+        Dim tracks = If(proj.AudioTracks, New List(Of AudioTrack)()).
+            Where(Function(track) track?.AudioProfile IsNot Nothing AndAlso Not TypeOf track.AudioProfile Is NullAudioProfile AndAlso track.IsRelevant).
+            Take(Math.Max(proj.AudioTracksAvailable, 0)).
+            ToList()
+
+        If tracks.Count = 0 Then
+            sb.AppendLine("No active audio output track is configured.")
+            sb.AppendLine()
+            Return
+        End If
+
+        For index = 0 To tracks.Count - 1
+            Dim ap = tracks(index).AudioProfile
+            sb.AppendLine($"#### Audio output {index + 1}")
+            sb.AppendLine()
+            AppendItem(sb, "Input type", GetFileType(ap.File))
+            AppendItem(sb, "Input selection", If(ap.Stream Is Nothing, "Individual audio file or unresolved stream", "Stream selected from a container"))
+            AppendItem(sb, "Profile type", GetTypeName(ap))
+            AppendItem(sb, "Decoder", ap.Decoder.ToString())
+            AppendItem(sb, "Decoding mode", ap.DecodingMode.ToString())
+            AppendItem(sb, "Output codec", ap.AudioCodec.ToString())
+            AppendItem(sb, "Output type", ap.OutputFileType)
+            If ap.Bitrate > 0 Then AppendItem(sb, "Configured bitrate", ap.Bitrate.ToString(CultureInfo.InvariantCulture) + " kb/s")
+            If ap.Delay <> 0 Then AppendItem(sb, "Delay", ap.Delay.ToString(CultureInfo.InvariantCulture) + " ms")
+            If ap.Gain <> 0 Then AppendItem(sb, "Gain", ap.Gain.ToString(CultureInfo.InvariantCulture) + " dB")
+
+            Dim guiProfile = TryCast(ap, GUIAudioProfile)
+            If guiProfile IsNot Nothing Then
+                AppendItem(sb, "Encoder", guiProfile.GetEncoder().ToString())
+                AppendItem(sb, "Processing path", $"{ap.Decoder} -> {ap.DecodingMode} -> {guiProfile.GetEncoder()} ({ap.AudioCodec})")
+                AppendItem(sb, "Channel mode", guiProfile.Params.ChannelsMode.ToString())
+                If guiProfile.Params.ChannelsMode <> ChannelsMode.Original AndAlso ap.Channels > 0 Then
+                    AppendItem(sb, "Configured channels", ap.Channels.ToString(CultureInfo.InvariantCulture))
+                End If
+                AppendItem(sb, "Normalize", YesNo(guiProfile.Params.Normalize))
+                If guiProfile.Params.SamplingRate > 0 Then AppendItem(sb, "Configured sample rate", guiProfile.Params.SamplingRate.ToString(CultureInfo.InvariantCulture) + " Hz")
+                If guiProfile.Params.Codec = AudioCodec.FLAC Then
+                    AppendItem(sb, "FLAC bit depth", If(guiProfile.Params.ffmpegFlacBitDepth > 0, CInt(guiProfile.Params.ffmpegFlacBitDepth).ToString(CultureInfo.InvariantCulture), "Same as source"))
+                End If
+                If guiProfile.Params.ProbeSize <> 5 Then AppendItem(sb, "Probe size", guiProfile.Params.ProbeSize.ToString(CultureInfo.InvariantCulture) + " MB")
+                If guiProfile.Params.AnalyzeDuration <> 5 Then AppendItem(sb, "Analyze duration", guiProfile.Params.AnalyzeDuration.ToString(CultureInfo.InvariantCulture) + "M")
+                AppendItem(sb, "Custom switches", PresentOrAbsent(Not String.IsNullOrWhiteSpace(guiProfile.Params.CustomSwitches)) + " (content omitted)")
+            Else
+                If ap.Channels > 0 Then AppendItem(sb, "Configured channels", ap.Channels.ToString(CultureInfo.InvariantCulture))
+                AppendItem(sb, "Processing path", $"{ap.Decoder} -> {ap.DecodingMode} -> {ap.AudioCodec}")
+            End If
+
+            AppendAudioStream(sb, ap.Stream)
+            sb.AppendLine()
+        Next
+    End Sub
+
+    Private Shared Sub AppendAudioStream(sb As StringBuilder, stream As AudioStream)
+        If stream Is Nothing Then
+            AppendItem(sb, "Selected input stream", "Metadata not available")
+            Return
+        End If
+
+        AppendItem(sb, "Selected input stream", (stream.Index + 1).ToString(CultureInfo.InvariantCulture))
+        If stream.ID > 0 Then AppendItem(sb, "Stream ID", stream.ID.ToString(CultureInfo.InvariantCulture))
+        If stream.StreamOrder >= 0 Then AppendItem(sb, "Stream order", stream.StreamOrder.ToString(CultureInfo.InvariantCulture))
+        AppendOptionalItem(sb, "Input format", stream.FormatString)
+        AppendOptionalItem(sb, "Input profile", stream.FormatProfile)
+        If stream.Channels > 0 Then AppendItem(sb, "Input channels", stream.Channels.ToString(CultureInfo.InvariantCulture))
+        If stream.SamplingRate > 0 Then AppendItem(sb, "Input sample rate", stream.SamplingRate.ToString(CultureInfo.InvariantCulture) + " Hz")
+        If stream.BitDepth > 0 Then AppendItem(sb, "Input bit depth", stream.BitDepth.ToString(CultureInfo.InvariantCulture))
+        If stream.Bitrate > 0 Then AppendItem(sb, "Input bitrate", stream.Bitrate.ToString(CultureInfo.InvariantCulture) + " b/s")
+        If stream.Delay <> 0 Then AppendItem(sb, "Input delay", stream.Delay.ToString(CultureInfo.InvariantCulture) + " ms")
+        If stream.Language IsNot Nothing Then AppendItem(sb, "Language", stream.Language.ThreeLetterCode)
+        AppendItem(sb, "Default stream", YesNo(stream.Default))
+        AppendItem(sb, "Forced stream", YesNo(stream.Forced))
+    End Sub
+
+    Private Shared Sub AppendTools(sb As StringBuilder, proj As Project)
+        AppendHeading(sb, "Relevant tools")
+
+        Dim tools As New SortedDictionary(Of String, String)(StringComparer.OrdinalIgnoreCase)
+        AddTool(tools, Package.ffmpeg)
+        AddTool(tools, Package.MediaInfo)
+
+        If proj.Script?.IsAviSynth Then AddTool(tools, Package.AviSynth)
+        If proj.Script?.IsVapourSynth Then AddTool(tools, Package.VapourSynth)
+
+        Dim basicVideoEncoder = TryCast(proj.VideoEncoder, BasicVideoEncoder)
+        If basicVideoEncoder IsNot Nothing Then AddTool(tools, basicVideoEncoder.CommandLineParams.Package)
+
+        For Each track In If(proj.AudioTracks, New List(Of AudioTrack)())
+            If track?.AudioProfile Is Nothing OrElse TypeOf track.AudioProfile Is NullAudioProfile OrElse Not track.IsRelevant Then Continue For
+            AddAudioTools(tools, track.AudioProfile)
+        Next
+
+        Dim logText = proj.Log?.ToString()
+        If Not String.IsNullOrWhiteSpace(logText) Then
+            For Each pack As Package In Package.Items.Values
+                If pack Is Nothing OrElse String.IsNullOrWhiteSpace(pack.Name) OrElse String.IsNullOrWhiteSpace(pack.Version) Then Continue For
+                If logText.IndexOf(pack.Name + " " + pack.Version, StringComparison.OrdinalIgnoreCase) >= 0 Then AddTool(tools, pack)
+            Next
+        End If
+
+        AppendItem(sb, "Coverage", "Configured core and encoders, plus versioned packages named in the current log")
+        For Each tool In tools
+            AppendItem(sb, tool.Key, If(String.IsNullOrWhiteSpace(tool.Value), "Version not recorded", tool.Value))
+        Next
+    End Sub
+
+    Private Shared Sub AddAudioTools(tools As IDictionary(Of String, String), profile As AudioProfile)
+        Select Case profile.Decoder
+            Case AudioDecoderMode.Automatic, AudioDecoderMode.ffmpeg
+                AddTool(tools, Package.ffmpeg)
+            Case AudioDecoderMode.FFAudioSource
+                AddTool(tools, Package.ffms2)
+            Case AudioDecoderMode.eac3to
+                AddTool(tools, Package.eac3to)
+            Case AudioDecoderMode.NicAudio
+                AddTool(tools, Package.NicAudio)
+        End Select
+
+        Dim guiProfile = TryCast(profile, GUIAudioProfile)
+        If guiProfile Is Nothing Then Return
+
+        Select Case guiProfile.GetEncoder()
+            Case GuiAudioEncoder.deezy
+                AddTool(tools, Package.DeeZy)
+            Case GuiAudioEncoder.eac3to
+                AddTool(tools, Package.eac3to)
+            Case GuiAudioEncoder.fdkaac
+                AddTool(tools, Package.fdkaac)
+            Case GuiAudioEncoder.opusenc
+                AddTool(tools, Package.OpusEnc)
+            Case GuiAudioEncoder.qaac
+                AddTool(tools, Package.qaac)
+            Case Else
+                AddTool(tools, If(guiProfile.Params.Codec = AudioCodec.AAC AndAlso guiProfile.Params.ffmpegLibFdkAAC, Package.ffmpeg_non_free, Package.ffmpeg))
+        End Select
+    End Sub
+
+    Private Shared Sub AppendFailureSummary(sb As StringBuilder, proj As Project)
+        AppendHeading(sb, "Failure summary")
+
+        Dim logText = proj.Log?.ToString()
+        AppendItem(sb, "Current log", If(String.IsNullOrWhiteSpace(logText), "No log content", "Available (raw content omitted)"))
+
+        If Not String.IsNullOrWhiteSpace(logText) Then
+            Dim exitCodes = Regex.Matches(logText, "returned exit code:\s*(-?\d+)\s*\(0x([0-9A-F]+)\)", RegexOptions.IgnoreCase).
+                OfType(Of Match)().
+                Select(Function(match) $"{match.Groups(1).Value} (0x{match.Groups(2).Value.ToUpperInvariant()})").
+                Distinct().
+                ToList()
+
+            AppendItem(sb, "Recorded failing exit codes", If(exitCodes.Count = 0, "None found", String.Join(", ", exitCodes)))
+        End If
+    End Sub
+
+    Private Shared Sub AppendCommands(sb As StringBuilder, proj As Project, includeCommands As Boolean)
+        AppendHeading(sb, "Command summary")
+
+        If Not includeCommands Then
+            sb.AppendLine("Sanitized commands were not included. Enable the command option in the preview only if they are needed, then review them before sharing.")
+            sb.AppendLine()
+            Return
+        End If
+
+        sb.AppendLine("Standard paths and every detected text-valued or custom argument are replaced. This is a best-effort summary, so review it before sharing.")
+        sb.AppendLine()
+
+        Dim videoCommand = GetSanitizedVideoCommand(proj)
+        AppendCommand(sb, "Video", videoCommand)
+
+        Dim audioIndex = 0
+        For Each track In If(proj.AudioTracks, New List(Of AudioTrack)())
+            If track?.AudioProfile Is Nothing OrElse TypeOf track.AudioProfile Is NullAudioProfile OrElse Not track.IsRelevant Then Continue For
+            audioIndex += 1
+            AppendCommand(sb, $"Audio {audioIndex}", GetSanitizedAudioCommand(proj, track.AudioProfile))
+        Next
+
+        sb.AppendLine("Muxer commands are omitted because muxer profiles can contain free-form command templates.")
+        sb.AppendLine()
+    End Sub
+
+    Private Shared Function GetSanitizedVideoCommand(proj As Project) As String
+        Dim encoder = TryCast(proj.VideoEncoder, BasicVideoEncoder)
+        If encoder Is Nothing Then Return "Unavailable for this encoder type"
+
+        Try
+            Dim sensitiveValues As New List(Of String) From {
+                proj.SourceFile,
+                proj.TargetFile,
+                proj.TempDir,
+                proj.TemplateName,
+                proj.CodeAtTop,
+                proj.CodeAtBottom,
+                proj.VideoEncoder.Name
+            }
+
+            For Each parameter In encoder.CommandLineParams.Items.OfType(Of StringParam)()
+                sensitiveValues.Add(parameter.Value)
+            Next
+
+            Return SanitizeCommandForReport(encoder.GetCommandLine(False, True), sensitiveValues)
+        Catch
+            Return "Unavailable in the current project state"
+        End Try
+    End Function
+
+    Private Shared Function GetSanitizedAudioCommand(proj As Project, profile As AudioProfile) As String
+        Dim guiProfile = TryCast(profile, GUIAudioProfile)
+        If guiProfile Is Nothing Then Return "Omitted for a free-form audio profile"
+
+        Try
+            Dim sensitiveValues As New List(Of String) From {
+                proj.SourceFile,
+                proj.TargetFile,
+                proj.TempDir,
+                proj.TemplateName,
+                profile.File,
+                profile.Name,
+                profile.StreamName,
+                guiProfile.Params.CustomSwitches
+            }
+
+            Return SanitizeCommandForReport(guiProfile.GetCommandLine(False), sensitiveValues)
+        Catch
+            Return "Unavailable in the current project state"
+        End Try
+    End Function
+
+    Friend Shared Function SanitizeCommandForReport(command As String, sensitiveValues As IEnumerable(Of String)) As String
+        If String.IsNullOrWhiteSpace(command) Then Return "Not available"
+
+        ' Commands are optional because external syntax is extensible. Remove every known free-form value first,
+        ' then apply generic path and credential guards. The preview still requires manual review.
+        Dim ret = command.Replace(Convert.ToChar(13), " "c).Replace(Convert.ToChar(10), " "c).Replace(Convert.ToChar(9), " "c)
+
+        If sensitiveValues IsNot Nothing Then
+            For Each value In sensitiveValues.Where(Function(item) Not String.IsNullOrWhiteSpace(item)).OrderByDescending(Function(item) item.Length)
+                ret = Regex.Replace(ret, Regex.Escape(value), "<REDACTED>", RegexOptions.IgnoreCase)
+            Next
+        End If
+
+        ret = Regex.Replace(ret, "(?i)\b(?:https?|ftp)://\S+", "<URL>")
+        ret = Regex.Replace(ret, "(?i)(?<![\w.-])[\w.+-]+@[\w.-]+\.[A-Z]{2,}(?![\w.-])", "<EMAIL>")
+        ret = Regex.Replace(ret, "(?i)(--?(?:api[-_]?key|authorization|cookie|key|pass(?:wd|word)|secret|token)\s*[=:]?\s*)(?:(""[^""]*"")|\S+)", "$1<REDACTED>")
+        ret = Regex.Replace(ret, "(?i)\b(Bearer|Basic)\s+[A-Z0-9._~+/=-]+", "$1 <REDACTED>")
+        ret = Regex.Replace(ret, "(?i)""(?:[A-Z]:\\|\\\\)[^""]*""", "<PATH>")
+        ret = Regex.Replace(ret, "(?i)(?<!\S)(?:[A-Z]:\\|\\\\).*?(?=\s+(?:--?[A-Z0-9]|/[A-Z?]|\|)|$)", "<PATH>")
+        ret = Regex.Replace(ret, "\s+", " ").Trim()
+        ret = ret.Replace("```", "'''")
+
+        If ret.Length > 4000 Then ret = ret.Substring(0, 4000) + " <TRUNCATED>"
+        Return ret
+    End Function
+
+    Private Shared Sub AppendReporterPrompts(sb As StringBuilder)
+        AppendHeading(sb, "Reporter notes")
+        sb.AppendLine("- Observed behavior:")
+        sb.AppendLine("- Expected behavior:")
+        sb.AppendLine("- Corruption or failure symptom:")
+        sb.AppendLine("- Reproduction frequency: Always / Intermittent / Once")
+        sb.AppendLine("- First failing StaxRip version:")
+        sb.AppendLine("- Last known working StaxRip version:")
+        sb.AppendLine("- Reproduces with a clean template: Yes / No / Not tested")
+        sb.AppendLine("- Reproduces with another source: Yes / No / Not tested")
+        sb.AppendLine("- Reproduces when the equivalent command is run outside StaxRip: Yes / No / Not tested")
+        sb.AppendLine("- Earliest affected timestamp or processing stage:")
+        sb.AppendLine("- Output validation performed (player, decoder check, MediaInfo, or comparison):")
+        sb.AppendLine()
+    End Sub
+
+    Private Shared Sub AppendPrivacySummary(sb As StringBuilder, commandsIncluded As Boolean)
+        AppendHeading(sb, "Privacy review")
+        AppendItem(sb, "Raw log", "Not included")
+        AppendItem(sb, "Paths and file names", "Not included")
+        AppendItem(sb, "Media and stream titles", "Not included")
+        AppendItem(sb, "Template and profile names", "Not included")
+        AppendItem(sb, "Scripts and custom text", "Not included")
+        AppendItem(sb, "Sanitized command summaries", If(commandsIncluded, "Included; manual review required", "Not included"))
+    End Sub
+
+    Private Shared Sub AppendCommand(sb As StringBuilder, heading As String, command As String)
+        sb.AppendLine($"#### {heading}")
+        sb.AppendLine()
+        sb.AppendLine("```text")
+        sb.AppendLine(command)
+        sb.AppendLine("```")
+        sb.AppendLine()
+    End Sub
+
+    Private Shared Sub AppendHeading(sb As StringBuilder, heading As String)
+        If sb.Length > 0 AndAlso Not sb.ToString().EndsWith(Environment.NewLine + Environment.NewLine, StringComparison.Ordinal) Then
+            sb.AppendLine()
+        End If
+
+        sb.AppendLine($"### {heading}")
+        sb.AppendLine()
+    End Sub
+
+    Private Shared Sub AppendItem(sb As StringBuilder, name As String, value As String)
+        sb.AppendLine($"- {name}: {SafeTechnicalValue(value)}")
+    End Sub
+
+    Private Shared Sub AppendOptionalItem(sb As StringBuilder, name As String, value As String)
+        If Not String.IsNullOrWhiteSpace(value) Then AppendItem(sb, name, value)
+    End Sub
+
+    Private Shared Function SafeTechnicalValue(value As String) As String
+        If String.IsNullOrWhiteSpace(value) Then Return "Not available"
+
+        If Regex.IsMatch(value, "(?i)(?:[A-Z]:\\|\\\\|/Users/|/home/|\b(?:https?|ftp)://)") Then
+            Return "Omitted"
+        End If
+
+        Dim ret = Regex.Replace(value, "\s+", " ").Trim()
+        ret = Regex.Replace(ret, "[^\p{L}\p{Nd} .,_+\-/:;=()\[\]#]", "?")
+        If ret.Length > 160 Then ret = ret.Substring(0, 160) + "..."
+        Return ret
+    End Function
+
+    Private Shared Function GetFrameServer(proj As Project) As String
+        If proj.Script Is Nothing Then Return "Not configured"
+        If proj.SkipVideoEncoding AndAlso Not proj.UseScriptAsAudioSource Then Return "Not used by the configured encode"
+        Return proj.Script.Engine.ToString()
+    End Function
+
+    Private Shared Function GetFileType(path As String) As String
+        If String.IsNullOrWhiteSpace(path) Then Return "Not available"
+
+        Try
+            Dim extension = IO.Path.GetExtension(path).TrimStart("."c)
+            Return If(extension = "", "No extension", extension.ToLowerInvariant())
+        Catch
+            Return "Not available"
+        End Try
+    End Function
+
+    Private Shared Function GetTypeName(value As Object) As String
+        Return If(value Is Nothing, "Not configured", value.GetType().Name)
+    End Function
+
+    Private Shared Function FormatVersion(version As Version) As String
+        Return $"{version.Major}.{version.Minor}.{version.Build}"
+    End Function
+
+    Private Shared Function OptionalSuffix(value As String) As String
+        Return If(String.IsNullOrWhiteSpace(value), "", " (" + value + ")")
+    End Function
+
+    Private Shared Function YesNo(value As Boolean) As String
+        Return If(value, "Yes", "No")
+    End Function
+
+    Private Shared Function PresentOrAbsent(value As Boolean) As String
+        Return If(value, "Present", "Not present")
+    End Function
+
+    Private Shared Sub AddTool(tools As IDictionary(Of String, String), package As Package)
+        If package Is Nothing OrElse String.IsNullOrWhiteSpace(package.Name) Then Return
+        tools(package.Name) = package.Version
+    End Sub
+End Class

--- a/Source/General/SupportReportBuilder.vb
+++ b/Source/General/SupportReportBuilder.vb
@@ -364,16 +364,17 @@ Public NotInheritable Class SupportReportBuilder
 
         If sensitiveValues IsNot Nothing Then
             For Each value In sensitiveValues.Where(Function(item) Not String.IsNullOrWhiteSpace(item)).OrderByDescending(Function(item) item.Length)
-                ret = Regex.Replace(ret, Regex.Escape(value), "<REDACTED>", RegexOptions.IgnoreCase)
+                ret = Regex.Replace(ret, Regex.Escape(value), "<REDACTED>", RegexOptions.IgnoreCase Or RegexOptions.CultureInvariant)
             Next
         End If
 
-        ret = Regex.Replace(ret, "(?i)\b(?:https?|ftp)://\S+", "<URL>")
-        ret = Regex.Replace(ret, "(?i)(?<![\w.-])[\w.+-]+@[\w.-]+\.[A-Z]{2,}(?![\w.-])", "<EMAIL>")
-        ret = Regex.Replace(ret, "(?i)(--?(?:api[-_]?key|authorization|cookie|key|pass(?:wd|word)|secret|token)\s*[=:]?\s*)(?:(""[^""]*"")|\S+)", "$1<REDACTED>")
-        ret = Regex.Replace(ret, "(?i)\b(Bearer|Basic)\s+[A-Z0-9._~+/=-]+", "$1 <REDACTED>")
-        ret = Regex.Replace(ret, "(?i)""(?:[A-Z]:\\|\\\\)[^""]*""", "<PATH>")
-        ret = Regex.Replace(ret, "(?i)(?<!\S)(?:[A-Z]:\\|\\\\).*?(?=\s+(?:--?[A-Z0-9]|/[A-Z?]|\|)|$)", "<PATH>")
+        Dim invariantIgnoreCase = RegexOptions.IgnoreCase Or RegexOptions.CultureInvariant
+        ret = Regex.Replace(ret, "\b(?:https?|ftp)://\S+", "<URL>", invariantIgnoreCase)
+        ret = Regex.Replace(ret, "(?<![\w.-])[\w.+-]+@[\w.-]+\.[A-Z]{2,}(?![\w.-])", "<EMAIL>", invariantIgnoreCase)
+        ret = Regex.Replace(ret, "(--?(?:api[-_]?key|authorization|cookie|key|pass(?:wd|word)|secret|token)\s*[=:]?\s*)(?:(""[^""]*"")|\S+)", "$1<REDACTED>", invariantIgnoreCase)
+        ret = Regex.Replace(ret, "\b(Bearer|Basic)\s+[A-Z0-9._~+/=-]+", "$1 <REDACTED>", invariantIgnoreCase)
+        ret = Regex.Replace(ret, """(?:[A-Z]:\\|\\\\)[^""]*""", "<PATH>", invariantIgnoreCase)
+        ret = Regex.Replace(ret, "(?<!\S)(?:[A-Z]:\\|\\\\).*?(?=\s+(?:--?[A-Z0-9]|/[A-Z?]|\|)|$)", "<PATH>", invariantIgnoreCase)
         ret = Regex.Replace(ret, "\s+", " ").Trim()
         ret = ret.Replace("```", "'''")
 
@@ -436,7 +437,7 @@ Public NotInheritable Class SupportReportBuilder
     Private Shared Function SafeTechnicalValue(value As String) As String
         If String.IsNullOrWhiteSpace(value) Then Return "Not available"
 
-        If Regex.IsMatch(value, "(?i)(?:[A-Z]:\\|\\\\|/Users/|/home/|\b(?:https?|ftp)://)") Then
+        If Regex.IsMatch(value, "(?:[A-Z]:\\|\\\\|/Users/|/home/|\b(?:https?|ftp)://)", RegexOptions.IgnoreCase Or RegexOptions.CultureInvariant) Then
             Return "Omitted"
         End If
 

--- a/Source/StaxRip.vbproj
+++ b/Source/StaxRip.vbproj
@@ -226,6 +226,9 @@
     <Compile Include="Forms\LogForm.vb">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Forms\SupportReportForm.vb">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="Forms\CodeForm.Designer.vb">
       <DependentUpon>CodeForm.vb</DependentUpon>
     </Compile>
@@ -250,6 +253,7 @@
     <Compile Include="Video\FrameServer.vb" />
     <Compile Include="General\JobManager.vb" />
     <Compile Include="General\LogBuilder.vb" />
+    <Compile Include="General\SupportReportBuilder.vb" />
     <Compile Include="General\GlobalClass.vb" />
     <Compile Include="General\GlobalCommands.vb" />
     <Compile Include="General\Macro.vb" />


### PR DESCRIPTION
## What changed

- add an editable `Help > Support Report Preview...` window and a Log File Viewer shortcut
- build the default Markdown report from an explicit diagnostic allowlist instead of copying the raw job log
- include workflow, source-video, selected audio-stream, tool-version, and numeric exit-code details that commonly determine whether an issue is reproducible
- offer sanitized encoder command summaries as an unchecked, best-effort option; omit muxer commands because their profiles can contain free-form templates
- make every case-insensitive redaction guard culture-invariant so values cannot survive under locales such as Turkish
- expand the bug-report issue form with subsystem, frequency, last-working-version, clean-template, frame-server, support-report, and privacy-review fields
- document the report boundary and problem-specific reporting guidance

## Why

Many reports contain the symptom but not the exact input path, processing chain, relevant tool versions, frequency, comparison conditions, or validation method. Other reports attach a complete log even though logs can contain paths, names, scripts, command lines, media metadata, and system details.

This gives reporters a smaller, human-readable starting point while keeping the raw log available for cases where a maintainer explicitly needs it. The diagnostic gaps visible in #1983 are one motivating example. This PR supersedes the narrower draft #1991.

## Privacy boundary

- the default report excludes raw logs, paths, file names, media and stream titles, template/profile names, scripts, custom text, URLs, credentials, exception text, and arbitrary tool output
- only known package name/version pairs and numeric failing exit codes are derived from the current log
- optional command summaries replace known string/custom values and apply generic path, URL, email, and credential guards
- the preview remains editable and repeatedly tells the reporter to review it before sharing

## User impact

Reporters can copy one Markdown block into the issue form. Maintainers get a consistent description of the active StaxRip workflow, including whether audio came from a file or container stream and which decoder/intermediate/encoder path was configured.

## Validation

- full `Debug|x64` solution rebuild
- full `Release|x64` solution rebuild
- 18 fixed sanitizer/allowlist assertions plus 100,000 deterministic fuzz cases across five recorded seeds
  - determinism and idempotence
  - Windows, UNC, Unix-user, URL, email, bearer/basic, and credential guards
  - declared sensitive values, Turkish UI culture, whitespace/control/Markdown normalization, output caps, and extension-only extraction
- actual-source mutation gate: 16/16 meaningful mutants killed, zero survivors, zero compile errors; two behaviorally equivalent mutants were identified and excluded with recorded reasons
- final Release executable staged over the verified official v2.52.5 portable x64 tree
  - fresh isolated-settings startup and changelog dismissal
  - `Help > Support Report Preview...` and `Log File Viewer > Ctrl+Shift+C`
  - command-summary checkbox off by default, report refresh after opt-in, editable preview, exact clipboard copy, visible copy acknowledgement, clean close, responsiveness, and exit code 0
  - empty project plus a synthetic H.264/AAC project; the populated report contained source/workflow details while the complete source path, file name, and base name remained absent in both command modes
- issue-form field-ID/schema checks
- all newly introduced relative documentation links resolved
- staged diff and report-boundary scans passed

The Release build retains the existing native FrameServer narrowing warnings; this change adds no managed build warnings.

Related x64 work in #1987, #1988, #1989, #1992, and #1993 separately exercised ten representative AviSynth/VapourSynth media and bundled-plugin cases, 5,000 frame-server lifecycles per engine, four GUI source-opening workflows, and a 3,928-file release-equivalent archive. Those results are useful regression evidence, but are not presented as feature-specific testing for this PR.

## Limits

- this feature candidate opened one representative synthetic H.264/AAC source; arbitrary user media, scripts, third-party plugins, hardware encoders, and every StaxRip form/command remain unbounded
- no multi-hour encode, cancellation, suspend/resume, disk-full, live-update, signing, publication, or hostile-input campaign was run
- the destructive hard-coded packaging/release scripts were not invoked; the final executable was tested in an isolated copy of the official portable package, while release-equivalent copy/archive behavior was validated separately in the related x64 work above
- sanitizer fuzzing and mutation testing were focused on the new privacy boundary rather than the entire legacy repository
- sanitized command summaries are optional and best effort; manual review is still required
