### PR TITLE
Video: fix the chunk-encode script synchronization race

### DIFF
--- a/Source/Video/VideoScript.vb
+++ b/Source/Video/VideoScript.vb
@@ -284,9 +284,16 @@ clipname.set_output()" + BR
             End If
         End If
 
+        ' The test below is a cache check that skips the rewrite when nothing has changed
+        ' since the last synchronization. Key it on the script BEFORE macro expansion:
+        ' %current_time%, %current_time24% and %random% expand to a new value on every call,
+        ' and a cache keyed on a value that changes on every read can never hit. That let
+        ' concurrent chunk-encode workers run this body simultaneously. The expanded text is
+        ' still what gets written; only the key is unexpanded.
+        Dim cacheKey = code
         code = Macro.Expand(code)
 
-        If Me.Error <> "" OrElse code <> LastCode OrElse (comparePath AndAlso Path <> LastPath) Then
+        If Me.Error <> "" OrElse cacheKey <> LastCode OrElse (comparePath AndAlso Path <> LastPath) Then
             If Path.Dir.DirExists Then
                 If Engine = ScriptEngine.VapourSynth Then
                     ModifyScript(code, Engine).WriteFileUTF8(Path)
@@ -312,7 +319,7 @@ clipname.set_output()" + BR
                     Me.Error = server.Error
                 End Using
 
-                LastCode = code
+                LastCode = cacheKey
                 LastPath = Path
             End If
         End If


### PR DESCRIPTION
## What changed

`Synchronize` skips its script rewrite when nothing has changed since the last call. The guard compared the macro-expanded script text against the `LastCode` cache. `%current_time%`, `%current_time24%` and `%random%` expand to a new value on every call, so with any of them in the script the comparison never held and the guard never short-circuited. This keys the cache on the script text before expansion. The expanded text is still what gets written; only the comparison key changes.

## Why it matters

During a chunked encode, `ProcessJob` synchronizes once and then runs the chunk actions through `Parallel.Invoke`. Each encoder's `Encode` calls `Synchronize` again, and with the guard defeated every worker runs the guarded body at the same time. Colliding writers to the same script file go into the ten-retry loop in `WriteFile` and can end raising an exception dialog from a worker thread; `Info`, `Error`, `LastCode` and `LastPath` are read and written with no synchronization; and `MainForm.Indexing()` runs off the UI thread.

This was observed on the released v2.52.5 x64 binary, not only in source: a probe drove `Synchronize` by reflection with the cache primed the way `ProcessJob` leaves it, and held the script file open to count threads inside the body. With a plain script, 0 of 8 concurrent callers entered. With one `%current_time%` token added, 8 of 8 were inside simultaneously.

## Impact

`LastCode` and `LastPath` are `NonSerialized` and have no reader outside `Synchronize`, so no persisted format, no project compatibility, and no other call site changes. The one behavior difference: a script whose only change is a volatile macro's expanded value no longer triggers a rewrite, which is the guard doing what it was written for.

## Validation

- StaxRip Debug x64 and Release x64 built with zero warnings and errors on top of `198223ea`.
- The reflection probe re-run against a build with this change: 0 of 8 threads enter the body in the volatile-macro case, while a genuinely changed script still triggers the rewrite in 8 of 8.
- The probe source, run logs, and the full analysis are on my fork under `Docs/Review/` on the `agent/chunk-sync-guard-fix` branch if wanted; they are left out of this PR to keep it to the one source file.

A full chunked encode with real media was not run; the concurrent-caller topology is established from `GlobalClass.ProcessJob` and the encoder `Encode` implementations, and the guard behavior by the probe above. How often real projects put a volatile macro in filter code was not measured.
